### PR TITLE
Update Chihuahua to v4.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
           - project: cheqd
             version: 0.6.9
           - project: chihuahua
-            version: v4.1.0
+            version: v4.2.0
           - project: comdex
             version: v7.0.0
           - project: cosmoshub

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[bostrom](https://github.com/cybercongress/go-cyber)|`v0.3.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-bostrom-v0.3.2`|[Example](./bostrom)|
 |[cerberus](https://github.com/cerberus-zone/cerberus)|`v3.0.1`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-cerberus-v3.0.1`|[Example](./cerberus)|
 |[cheqd](https://github.com/cheqd/cheqd-node)|`0.6.9`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-cheqd-0.6.9`|[Example](./cheqd)|
-|[chihuahua](https://github.com/ChihuahuaChain/chihuahua)|`v4.1.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-chihuahua-v4.1.0`|[Example](./chihuahua)|
+|[chihuahua](https://github.com/ChihuahuaChain/chihuahua)|`v4.2.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-chihuahua-v4.2.0`|[Example](./chihuahua)|
 |[comdex](https://github.com/comdex-official/comdex)|`v7.0.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-comdex-v7.0.0`|[Example](./comdex)|
 |[cosmoshub](https://github.com/cosmos/gaia)|`v7.1.0`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-cosmoshub-v7.1.0`|[Example](./cosmoshub)|
 |[cronos](https://github.com/crypto-org-chain/cronos)|`v0.8.2`|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-cronos-v0.8.2`|[Example](./cronos)|

--- a/chihuahua/README.md
+++ b/chihuahua/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v4.1.0`|
+|Version|`v4.2.0`|
 |Binary|`chihuahuad`|
 |Directory|`.chihuahuad`|
 |ENV namespace|`CHIHUAHUAD`|
 |Repository|`https://github.com/ChihuahuaChain/chihuahua`|
-|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-chihuahua-v4.1.0`|
+|Image|`ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-chihuahua-v4.2.0`|
 
 ## Examples
 

--- a/chihuahua/build.yml
+++ b/chihuahua/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: chihuahua
         PROJECT_BIN: chihuahuad
-        VERSION: v4.1.0
+        VERSION: v4.2.0
         REPOSITORY: https://github.com/ChihuahuaChain/chihuahua
         NAMESPACE: CHIHUAHUAD
         PROJECT_DIR: .chihuahuad

--- a/chihuahua/deploy.yml
+++ b/chihuahua/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-chihuahua-v4.1.0
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-chihuahua-v4.2.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/chain.json

--- a/chihuahua/docker-compose.yml
+++ b/chihuahua/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-chihuahua-v4.1.0
+    image: ghcr.io/ovrclk/cosmos-omnibus:v0.3.20-chihuahua-v4.2.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Update: https://www.mintscan.io/chihuahua/proposals/44
Block: https://www.mintscan.io/chihuahua/blocks/6039999 (Thu Feb 09 2023 12:55:58 GMT+0000)

Pre-release images:

```
ghcr.io/akash-network/cosmos-omnibus:v0.3.23-rc1-chihuahua-v4.2.0
```