### PR TITLE
polkachu disabled the /snapshot API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ Note that snapshots will be restored in-process, without downloading the snapsho
 |`SNAPSHOT_WASM_PATH`|The path to the wasm directory within the archive, if exists outside of data| |`snapshot/wasm`|
 |`SNAPSHOT_PRUNING`|Type of snapshot to download, e.g. `archive`, `pruned`, `default`.|`pruned`|`archive`|
 |`SNAPSHOT_QUICKSYNC`|A URL to a Quicksync JSON file describing their snapshots. Also see `SNAPSHOT_PRUNING`| |`https://quicksync.io/terra.json`|
-|`SNAPSHOT_POLKACHU`|Import [Polkachu's](https://www.polkachu.com/tendermint_snapshots) snapshot automatically if available| |`1`|
 
 ### Snapshot backup
 

--- a/agoric/README.MD
+++ b/agoric/README.MD
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/agoric/build.yml
+++ b/agoric/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/agoric/deploy.yml
+++ b/agoric/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/agoric/docker-compose.yml
+++ b/agoric/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.agoric

--- a/akash/README.md
+++ b/akash/README.md
@@ -40,7 +40,6 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|
 
 ## Akash Snapshots

--- a/akash/build.yml
+++ b/akash/build.yml
@@ -21,7 +21,6 @@ services:
       - FASTSYNC_VERSION=v0
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/akash/deploy.yml
+++ b/akash/deploy.yml
@@ -10,8 +10,7 @@ services:
       - MINIMUM_GAS_PRICES=0.025uakt
       - FASTSYNC_VERSION=v0
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/akash/docker-compose.yml
+++ b/akash/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - MINIMUM_GAS_PRICES=0.025uakt
       - FASTSYNC_VERSION=v0
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.akash

--- a/assetmantle/README.md
+++ b/assetmantle/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/assetmantle/build.yml
+++ b/assetmantle/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/assetmantle/deploy.yml
+++ b/assetmantle/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/assetmantle/docker-compose.yml
+++ b/assetmantle/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.mantleNode

--- a/bitcanna/README.md
+++ b/bitcanna/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/bitcanna/build.yml
+++ b/bitcanna/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/bitcanna/deploy.yml
+++ b/bitcanna/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/bitcanna/docker-compose.yml
+++ b/bitcanna/docker-compose.yml
@@ -11,8 +11,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/cerberus/README.md
+++ b/cerberus/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/cerberus/build.yml
+++ b/cerberus/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/cerberus/deploy.yml
+++ b/cerberus/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/cerberus/docker-compose.yml
+++ b/cerberus/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.cerberus

--- a/chihuahua/README.md
+++ b/chihuahua/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/chihuahua/build.yml
+++ b/chihuahua/build.yml
@@ -21,7 +21,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/chihuahua/deploy.yml
+++ b/chihuahua/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/chihuahua/docker-compose.yml
+++ b/chihuahua/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.chihuahuad

--- a/comdex/README.md
+++ b/comdex/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/comdex/build.yml
+++ b/comdex/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/comdex/deploy.yml
+++ b/comdex/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/comdex/docker-compose.yml
+++ b/comdex/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.comdex

--- a/cosmoshub/README.md
+++ b/cosmoshub/README.md
@@ -31,7 +31,6 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|
 
 ## ChainLayer Quicksync

--- a/cosmoshub/build.yml
+++ b/cosmoshub/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/cosmoshub/deploy.yml
+++ b/cosmoshub/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/cosmoshub/docker-compose.yml
+++ b/cosmoshub/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.gaia

--- a/evmos/README.md
+++ b/evmos/README.md
@@ -31,7 +31,6 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|
 
 ## Skip MEV support

--- a/evmos/build-skip.yml
+++ b/evmos/build-skip.yml
@@ -23,7 +23,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/evmos/build.yml
+++ b/evmos/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/evmos/deploy.yml
+++ b/evmos/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/evmos/docker-compose.yml
+++ b/evmos/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.evmosd

--- a/fetchhub/README.md
+++ b/fetchhub/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/fetchhub/build.yml
+++ b/fetchhub/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/fetchhub/deploy.yml
+++ b/fetchhub/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/fetchhub/docker-compose.yml
+++ b/fetchhub/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.fetchd

--- a/gravitybridge/README.md
+++ b/gravitybridge/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/gravitybridge/build.yml
+++ b/gravitybridge/build.yml
@@ -19,7 +19,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/gravitybridge/deploy.yml
+++ b/gravitybridge/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/gravitybridge/docker-compose.yml
+++ b/gravitybridge/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.gravity

--- a/jackal/build.yml
+++ b/jackal/build.yml
@@ -23,7 +23,6 @@ services:
       - MINIMUM_GAS_PRICES=0.002ujkl
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/jackal/deploy.yml
+++ b/jackal/deploy.yml
@@ -11,8 +11,7 @@ services:
       - P2P_SEEDS=ec38fb158ffb0272c4b7c951fc790a8f9849e280@198.244.212.27:26656,ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:17556
       - MINIMUM_GAS_PRICES=0.002ujkl
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/jackal/docker-compose.yml
+++ b/jackal/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - P2P_SEEDS=ec38fb158ffb0272c4b7c951fc790a8f9849e280@198.244.212.27:26656,ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:17556
       - MINIMUM_GAS_PRICES=0.002ujkl
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.canine

--- a/juno/README.md
+++ b/juno/README.md
@@ -31,7 +31,6 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|
 
 ## Skip MEV support

--- a/juno/build-skip.yml
+++ b/juno/build-skip.yml
@@ -25,7 +25,6 @@ services:
       - GENESIS_FILENAME=juno-phoenix2-genesis.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
       # These IAVL settings are required starting juno v11.0.0
       # https://github.com/CosmosContracts/juno/releases/tag/v11.0.0
       - JUNOD_IAVL_CACHE_SIZE=781250

--- a/juno/build.yml
+++ b/juno/build.yml
@@ -22,7 +22,6 @@ services:
       - GENESIS_FILENAME=juno-phoenix2-genesis.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
       # These IAVL settings are required starting juno v11.0.0
       # https://github.com/CosmosContracts/juno/releases/tag/v11.0.0
       - JUNOD_IAVL_CACHE_SIZE=781250

--- a/juno/deploy.yml
+++ b/juno/deploy.yml
@@ -10,8 +10,7 @@ services:
       - GENESIS_URL=https://download.dimi.sh/juno-phoenix2-genesis.tar.gz
       - GENESIS_FILENAME=juno-phoenix2-genesis.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
       # These IAVL settings are required starting juno v11.0.0
       # https://github.com/CosmosContracts/juno/releases/tag/v11.0.0
       - JUNOD_IAVL_CACHE_SIZE=781250

--- a/juno/docker-compose.yml
+++ b/juno/docker-compose.yml
@@ -13,8 +13,7 @@ services:
       - GENESIS_URL=https://download.dimi.sh/juno-phoenix2-genesis.tar.gz
       - GENESIS_FILENAME=juno-phoenix2-genesis.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
       # These IAVL settings are required starting juno v11.0.0
       # https://github.com/CosmosContracts/juno/releases/tag/v11.0.0
       - JUNOD_IAVL_CACHE_SIZE=781250

--- a/kava/README.md
+++ b/kava/README.md
@@ -31,7 +31,6 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|
 
 ## ChainLayer Quicksync

--- a/kava/build.yml
+++ b/kava/build.yml
@@ -19,7 +19,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/kava/deploy.yml
+++ b/kava/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/kava/docker-compose.yml
+++ b/kava/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.kava

--- a/kichain/README.md
+++ b/kichain/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/kichain/build.yml
+++ b/kichain/build.yml
@@ -18,8 +18,8 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/chain.json
       - P2P_POLKACHU=1
-      - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
+      # enable when supported https://polkachu.com/networks/kichain
+      #- STATESYNC_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/kichain/deploy.yml
+++ b/kichain/deploy.yml
@@ -8,8 +8,8 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      # enable when supported https://polkachu.com/networks/kichain
+      #- STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/kichain/docker-compose.yml
+++ b/kichain/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      # enable when supported https://polkachu.com/networks/kichain
+      #- STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.kid

--- a/konstellation/README.md
+++ b/konstellation/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/konstellation/build.yml
+++ b/konstellation/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/konstellation/deploy.yml
+++ b/konstellation/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/konstellation/docker-compose.yml
+++ b/konstellation/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.knstld

--- a/osmosis/README.md
+++ b/osmosis/README.md
@@ -31,7 +31,6 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|
 
 ## ChainLayer Quicksync

--- a/osmosis/build.yml
+++ b/osmosis/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
       # - SNAPSHOT_WASM_PATH=wasm
     env_file:
       - ../.env

--- a/osmosis/deploy.yml
+++ b/osmosis/deploy.yml
@@ -8,9 +8,8 @@ services:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
-      - SNAPSHOT_WASM_PATH=wasm
+      - STATESYNC_POLKACHU=1
+      #- SNAPSHOT_WASM_PATH=wasm
       ## Make sure to set SNAPSHOT_DATA_PATH=data when using snapshots with the directory structure // TODO: https://github.com/akash-network/cosmos-omnibus/issues/378
       # - SNAPSHOT_URL=https://snapshots.polkachu.com/snapshots/osmosis/osmosis_7268027.tar.lz4
       # - SNAPSHOT_DATA_PATH=data

--- a/osmosis/docker-compose.yml
+++ b/osmosis/docker-compose.yml
@@ -11,9 +11,8 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
-      - SNAPSHOT_WASM_PATH=wasm
+      - STATESYNC_POLKACHU=1
+      #- SNAPSHOT_WASM_PATH=wasm
       ## Make sure to set SNAPSHOT_DATA_PATH=data when using snapshots with the directory structure // TODO: https://github.com/akash-network/cosmos-omnibus/issues/378
       # - SNAPSHOT_URL=https://snapshots.polkachu.com/snapshots/osmosis/osmosis_7268027.tar.lz4
       # - SNAPSHOT_DATA_PATH=data

--- a/run.sh
+++ b/run.sh
@@ -101,7 +101,7 @@ export "${NAMESPACE}_RPC_LADDR"="${RPC_LADDR:-tcp://0.0.0.0:26657}"
 [ -n "$PRUNING_KEEP_RECENT" ] && export "${NAMESPACE}_PRUNING_KEEP_RECENT"=$PRUNING_KEEP_RECENT
 
 # Polkachu
-if [[ -n "$P2P_POLKACHU" || -n "$SNAPSHOT_POLKACHU" || -n "$STATESYNC_POLKACHU" ]]; then
+if [[ -n "$P2P_POLKACHU" || -n "$STATESYNC_POLKACHU" ]]; then
   POLKACHU_CHAIN=`curl -s https://polkachu.com/api/v1/chains | jq -r --arg CHAIN_ID "$CHAIN_ID" 'first(.[] | select(.chain_id==$CHAIN_ID))'`
   if [ -z "$POLKACHU_CHAIN" ]; then
     echo "Polkachu does not support this chain"
@@ -129,24 +129,6 @@ if [[ -n "$P2P_POLKACHU" || -n "$SNAPSHOT_POLKACHU" || -n "$STATESYNC_POLKACHU" 
       fi
     fi
 
-    # Polkachu snapshot
-    if [ -n "$SNAPSHOT_POLKACHU" ]; then
-      export POLKACHU_SNAPSHOT_ENABLED=$(echo $POLKACHU_CHAIN | jq -r '.snapshot.active')
-      if [ $POLKACHU_SNAPSHOT_ENABLED ]; then
-        export POLKACHU_SNAPSHOT=`curl -Ls $(echo $POLKACHU_CHAIN | jq -r '.snapshot.endpoint') | jq -r '.snapshot.url'`
-        if [[ "$POLKACHU_SNAPSHOT" == "null" ]]; then
-          echo "Issue obtaining the Polkachu snapshot. Likely the API issue."
-          echo "Sleeping for 10 minutes before restarting..."
-          sleep 600
-          exit 1
-        else
-          export SNAPSHOT_URL=$POLKACHU_SNAPSHOT
-          export SNAPSHOT_DATA_PATH=data
-        fi
-      else
-        echo "Polkachu snapshot is not active for this chain"
-      fi
-    fi
   fi
 fi
 

--- a/shentu/README.md
+++ b/shentu/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/shentu/build.yml
+++ b/shentu/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/shentu/deploy.yml
+++ b/shentu/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/shentu/docker-compose.yml
+++ b/shentu/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.certik

--- a/sifchain/README.md
+++ b/sifchain/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/sifchain/build.yml
+++ b/sifchain/build.yml
@@ -18,7 +18,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/sifchain/deploy.yml
+++ b/sifchain/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/sifchain/docker-compose.yml
+++ b/sifchain/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.sifnoded

--- a/stargaze/README.md
+++ b/stargaze/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/stargaze/build.yml
+++ b/stargaze/build.yml
@@ -21,7 +21,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
       # - SNAPSHOT_WASM_PATH=wasm
     env_file:
       - ../.env

--- a/stargaze/deploy.yml
+++ b/stargaze/deploy.yml
@@ -8,9 +8,8 @@ services:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
-      - SNAPSHOT_WASM_PATH=wasm
+      - STATESYNC_POLKACHU=1
+      #- SNAPSHOT_WASM_PATH=wasm
     expose:
       - port: 26657
         as: 80

--- a/stargaze/docker-compose.yml
+++ b/stargaze/docker-compose.yml
@@ -11,8 +11,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
-      - SNAPSHOT_WASM_PATH=wasm
+      - STATESYNC_POLKACHU=1
+      #- SNAPSHOT_WASM_PATH=wasm
     volumes:
       - ./node-data:/root/.starsd

--- a/stride/README.md
+++ b/stride/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/stride/build.yml
+++ b/stride/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/stride/deploy.yml
+++ b/stride/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/stride/docker-compose.yml
+++ b/stride/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.stride

--- a/umee/README.md
+++ b/umee/README.md
@@ -31,5 +31,4 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |Variable|Value|
 |---|---|
 |`P2P_POLKACHU`|`1`|
-|`SNAPSHOT_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|

--- a/umee/build.yml
+++ b/umee/build.yml
@@ -20,7 +20,6 @@ services:
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/chain.json
       - P2P_POLKACHU=1
       - STATESYNC_POLKACHU=1
-      # - SNAPSHOT_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/umee/deploy.yml
+++ b/umee/deploy.yml
@@ -8,8 +8,7 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/umee/docker-compose.yml
+++ b/umee/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/chain.json
       - P2P_POLKACHU=1
-      # - STATESYNC_POLKACHU=1
-      - SNAPSHOT_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.umee


### PR DESCRIPTION
people can't deploy their nodes/validators and :
1. https://discord.com/channels/747885925232672829/771909909335506955/1076170431054225478
2. https://github.com/akash-network/cosmos-omnibus/issues/387

```
$ curl -L  http://polkachu.com/api/v1/chains/axelar/snapshot
{"success":false,"reason":"Temporarily unavailable. Please contact hello@polkachu.com to get your IP whitelisted to access this endpoint."}
```

Polkachu won't likely to re-open their snapshot API:
> (`20th of January 2023`): The biggest issue we had is that people abuse the API and just download snapshots daily for no good reasons and max out the network bandwidth for us


Hence, let's remove the `SNAPSHOT_POLKACHU` (/snapshot API) entirely.

Let's default to the state-sync which is faster and better.

The list of the chains with the active state-sync provided by Polkachu (on `20th of February 2023`):

```
$ curl -s https://polkachu.com/api/v1/chains | jq -r '.[] | [.network, .state_sync.active] | @csv' | column -s"," -t
"agoric"         true
"akash"          true
"assetmantle"    true
"axelar"         true
"bitcanna"       true
"canto"          true
"carbon"         true
"cerberus"       true
"certik"         true
"chihuahua"      true
"comdex"         true
"cosmos"         true
"crescent"       true
"cryptocom"      true
"evmos"          true
"fetch"          true
"gravity"        true
"injective"      true
"jackal"         true
"joe"            true
"juno"           true
"kava"           true
"kichain"        false
"konstellation"  true
"kujira"         true
"loyal"          true
"mars"           true
"meme"           true
"nomic"          false
"nym"            true
"osmosis"        true
"passage"        true
"persistence"    true
"planq"          true
"quicksilver"    true
"sifchain"       true
"sommelier"      true
"stargaze"       true
"stride"         true
"teritori"       true
"terra"          true
"umee"           true
"whitewhale"     true
"xpla"           true
```
