### PR TITLE
gaia: bump mem reqs

### DIFF
--- a/cosmoshub/deploy.yml
+++ b/cosmoshub/deploy.yml
@@ -29,7 +29,7 @@ profiles:
         cpu:
           units: 4
         memory:
-          size: 8Gi
+          size: 16Gi
         storage:
           size: 100Gi
           # - size: 100Mi


### PR DESCRIPTION
8Gi of RAM isn't enough, it'll get OOM killed. (got OOM killed during the state-sync phase in my test today)

refs https://hub.cosmos.network/main/hub-tutorials/join-mainnet.html#hardware