### PR TITLE
run.sh: add snapshot destination in tar cmd

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -257,9 +257,9 @@ if [ "$DOWNLOAD_SNAPSHOT" == "1" ]; then
 
     tar_cmd="tar xf -"
     # case insensitive match
-    if [[ "${SNAPSHOT_FORMAT,,}" == "tar.gz" ]]; then tar_cmd="tar xzf -"; fi
-    if [[ "${SNAPSHOT_FORMAT,,}" == "tar.lz4" ]]; then tar_cmd="lz4 -d | tar xf -"; fi
-    if [[ "${SNAPSHOT_FORMAT,,}" == "tar.zst" ]]; then tar_cmd="zstd -cd | tar xf -"; fi
+    if [[ "${SNAPSHOT_FORMAT,,}" == "tar.gz" ]]; then tar_cmd="tar xzf - -C $PROJECT_ROOT"; fi
+    if [[ "${SNAPSHOT_FORMAT,,}" == "tar.lz4" ]]; then tar_cmd="lz4 -d | tar xf - -C $PROJECT_ROOT"; fi
+    if [[ "${SNAPSHOT_FORMAT,,}" == "tar.zst" ]]; then tar_cmd="zstd -cd | tar xf - -C $PROJECT_ROOT"; fi
 
     # Detect content size via HTTP header `Content-Length`
     # Note that the server can refuse to return `Content-Length`, or the URL can be incorrect


### PR DESCRIPTION
When a SNAPSHOT_URL is specified, the content is stored in $PROJECT_ROOT/data/data. For example: -e SNAPSHOT_URL=https://snapshots.polkachu.com/snapshots/akash/akash_10400871.tar.lz4 And the earliest and latest block time are "earliest_block_time": "1970-01-01T00:00:00Z".

run.sh is deleting the current data directory, with the destitation in the tar command, the snapshot is stored in $PROJECT_ROOT/data and the block data are correct.