### PR TITLE
add image for kava mainnet update to v0.23.0

### DIFF
--- a/kava/build.yml
+++ b/kava/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: kava
         PROJECT_BIN: kava
-        VERSION: v0.21.0
+        VERSION: v0.23.0
         REPOSITORY: https://github.com/Kava-Labs/kava
         NAMESPACE: KAVA
     ports:


### PR DESCRIPTION
Updates the build.yml for kava to v0.23.0 for mainnet upgrade at block https://www.mintscan.io/kava/blocks/4832500