### PR TITLE
Remove Akash snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,15 +136,6 @@ Omnibus can [import chain snapshots](#snapshot-restore) from almost any location
 
 Appropriate snapshot configuration is included in most example configurations in the Omnibus repository. Check the project directories for more information.
 
-Akash also generate and publish snapshots for the Akash blockchain. Pruned snapshots are taken daily, and Archive snapshots weekly.
-
-These snapshots are created using Omnibus nodes running on Akash, as shown in the [Snapshot Backup](_examples/snapshot_backup) example.
-
-|Type|Snapshot JSON|
-|---|---|
-|Akash Pruned|https://cosmos-snapshots.s3.filebase.com/akash/pruned/snapshot.json|
-|Akash Archive|https://cosmos-snapshots.s3.filebase.com/akash/snapshot.json|
-
 ## Examples
 
 See the [_examples](./_examples) directory for some common setups, including:

--- a/_examples/load-balanced-rpc-nodes/node_deploy.yml
+++ b/_examples/load-balanced-rpc-nodes/node_deploy.yml
@@ -7,9 +7,10 @@ services:
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/master/mainnet/meta.json
-      - SNAPSHOT_JSON=https://cosmos-snapshots.s3.filebase.com/akash/pruned/snapshot.json
       - MINIMUM_GAS_PRICES=0.025uakt
       - FASTSYNC_VERSION=v0
+      - P2P_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         to:

--- a/_examples/snapshot_backup/deploy.yml
+++ b/_examples/snapshot_backup/deploy.yml
@@ -7,9 +7,10 @@ services:
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/master/mainnet/meta.json
-      - SNAPSHOT_JSON=https://cosmos-snapshots.s3.filebase.com/akash/pruned/snapshot.json
+      - MINIMUM_GAS_PRICES=0.025uakt
       - FASTSYNC_VERSION=v0
-      - PRUNING=nothing
+      - P2P_POLKACHU=1
+      - STATESYNC_POLKACHU=1
       - S3_KEY=<s3-key>
       - S3_SECRET=<s3-secret>
       - SNAPSHOT_PATH=<bucket/path>

--- a/_examples/statesync/snapshot-deploy.yml
+++ b/_examples/statesync/snapshot-deploy.yml
@@ -7,9 +7,10 @@ services:
     env:
       - MONIKER=public-node-1
       - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/master/mainnet/meta.json
-      - SNAPSHOT_JSON=https://cosmos-snapshots.s3.filebase.com/akash/pruned/snapshot.json
       - MINIMUM_GAS_PRICES=0.025uakt
       - FASTSYNC_VERSION=v0
+      - P2P_POLKACHU=1
+      - STATESYNC_POLKACHU=1
       - PRUNING=nothing
       - STATESYNC_SNAPSHOT_INTERVAL=500
     expose:
@@ -29,9 +30,10 @@ services:
     env:
       - MONIKER=public-node-2
       - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/master/mainnet/meta.json
-      - SNAPSHOT_JSON=https://cosmos-snapshots.s3.filebase.com/akash/pruned/snapshot.json
       - MINIMUM_GAS_PRICES=0.025uakt
       - FASTSYNC_VERSION=v0
+      - P2P_POLKACHU=1
+      - STATESYNC_POLKACHU=1
       - PRUNING=nothing
       - STATESYNC_SNAPSHOT_INTERVAL=500
     expose:

--- a/akash/README.md
+++ b/akash/README.md
@@ -41,11 +41,3 @@ Note you should choose between statesync and snapshot bootstrapping, snapshot wi
 |---|---|
 |`P2P_POLKACHU`|`1`|
 |`STATESYNC_POLKACHU`|`1`|
-
-## Akash Snapshots
-
-Akash provide daily snapshots of the Akash blockchain taken at midnight UTC.
-
-|Variable|Value|
-|---|---|
-|`SNAPSHOT_JSON`|`https://cosmos-snapshots.s3.filebase.com/akash/pruned/snapshot.json`|

--- a/sentinel/build.yml
+++ b/sentinel/build.yml
@@ -16,7 +16,6 @@ services:
     environment:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/chain.json
-      # - SNAPSHOT_JSON=https://cosmos-snapshots.s3.filebase.com/sentinel/snapshot.json
     env_file:
       - ../.env
     volumes:

--- a/sentinel/deploy.yml
+++ b/sentinel/deploy.yml
@@ -7,7 +7,6 @@ services:
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/chain.json
-      - SNAPSHOT_JSON=https://cosmos-snapshots.s3.filebase.com/sentinel/snapshot.json
     expose:
       - port: 26657
         as: 80

--- a/sentinel/docker-compose.yml
+++ b/sentinel/docker-compose.yml
@@ -10,6 +10,5 @@ services:
     environment:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/chain.json
-      - SNAPSHOT_JSON=https://cosmos-snapshots.s3.filebase.com/sentinel/snapshot.json
     volumes:
       - ./node-data:/root/.sentinelhub


### PR DESCRIPTION
The snapshots for Akash were not up to date, and there are many better options now via Polkachu and other providers. Removing these snapshot examples from the docs.