### PR TITLE
Update Stargaze to v10.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,7 +125,7 @@ jobs:
           - project: sommelier
             version: v4.0.2
           - project: stargaze
-            version: v8.0.0
+            version: v10.0.0
           - project: stride
             version: v9.0.1
           - project: starname

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[shentu](https://github.com/certikfoundation/shentu)|`v2.5.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-shentu-v2.5.0`|[Example](./shentu)|
 |[sifchain](https://github.com/Sifchain/sifnode)|`v1.1.0-beta`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-sifchain-v1.1.0-beta`|[Example](./sifchain)|
 |[sommelier](https://github.com/PeggyJV/sommelier)|`v4.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-sommelier-v4.0.2`|[Example](./sommelier)|
-|[stargaze](https://github.com/public-awesome/stargaze)|`v8.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stargaze-v8.0.0`|[Example](./stargaze)|
+|[stargaze](https://github.com/public-awesome/stargaze)|`v10.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stargaze-v10.0.0`|[Example](./stargaze)|
 |[starname](https://github.com/iov-one/starnamed)|`v0.11.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-starname-v0.11.5`|[Example](./starname)|
 |[stride](https://github.com/Stride-Labs/stride)|`v9.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stride-v9.0.1`|[Example](./stride)|
 |[teritori](https://github.com/TERITORI/teritori-chain)|`v1.3.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-teritori-v1.3.1`|[Example](./teritori)|

--- a/stargaze/README.md
+++ b/stargaze/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v8.0.0`|
+|Version|`v10.0.0`|
 |Binary|`starsd`|
 |Directory|`.starsd`|
 |ENV namespace|`STARSD`|
 |Repository|`https://github.com/public-awesome/stargaze`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stargaze-v8.0.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stargaze-v10.0.0`|
 
 ## Examples
 

--- a/stargaze/build.yml
+++ b/stargaze/build.yml
@@ -8,10 +8,10 @@ services:
         PROJECT: stargaze
         PROJECT_BIN: starsd
         PROJECT_DIR: .starsd
-        VERSION: v8.0.0
+        VERSION: v10.0.0
         REPOSITORY: https://github.com/public-awesome/stargaze
         NAMESPACE: STARSD
-        GOLANG_VERSION: 1.19-buster
+        GOLANG_VERSION: 1.20-buster
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/stargaze/deploy.yml
+++ b/stargaze/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stargaze-v8.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stargaze-v10.0.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/chain.json

--- a/stargaze/docker-compose.yml
+++ b/stargaze/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stargaze-v8.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stargaze-v10.0.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
The upgrade is scheduled for block 8576398, which should be about 17:30 UTC on 8th June 2023. 

Useful links:
- https://www.mintscan.io/stargaze/proposals/172
- https://github.com/public-awesome/mainnet/blob/main/stargaze-1/v10_0_0_UPGRADE.md
- https://www.mintscan.io/stargaze/blocks/8576398