### PR TITLE
Update Teritori to v1.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,7 +131,7 @@ jobs:
           - project: starname
             version: v0.11.5
           - project: teritori
-            version: v1.3.1
+            version: v1.4.0
           # - project: terra
           #   version: v0.5.18
           - project: umee

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[stargaze](https://github.com/public-awesome/stargaze)|`v8.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stargaze-v8.0.0`|[Example](./stargaze)|
 |[starname](https://github.com/iov-one/starnamed)|`v0.11.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-starname-v0.11.5`|[Example](./starname)|
 |[stride](https://github.com/Stride-Labs/stride)|`v9.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-stride-v9.0.1`|[Example](./stride)|
-|[teritori](https://github.com/TERITORI/teritori-chain)|`v1.3.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-teritori-v1.3.1`|[Example](./teritori)|
+|[teritori](https://github.com/TERITORI/teritori-chain)|`v1.4.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-teritori-v1.4.0`|[Example](./teritori)|
 |[umee](https://github.com/umee-network/umee)|`v3.1.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-umee-v3.1.0`|[Example](./umee)|
 |[vidulum](https://github.com/vidulum/mainnet)|`v1.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-vidulum-v1.2.0`|[Example](./vidulum)|
 

--- a/teritori/README.md
+++ b/teritori/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.3.1`|
+|Version|`v1.4.0`|
 |Binary|`teritorid`|
 |Directory|`.teritorid`|
 |ENV namespace|`TERITORID`|
 |Repository|`https://github.com/TERITORI/teritori-chain`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-teritori-v1.3.1`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.34-teritori-v1.4.0`|
 
 ## Examples
 

--- a/teritori/build.yml
+++ b/teritori/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: teritori
         PROJECT_BIN: teritorid
-        VERSION: v1.3.1
+        VERSION: v1.4.0
         REPOSITORY: https://github.com/TERITORI/teritori-chain
         NAMESPACE: TERITORID
         PROJECT_DIR: .teritorid

--- a/teritori/deploy.yml
+++ b/teritori/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.34-teritori-v1.3.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.34-teritori-v1.4.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_ID=teritori-1

--- a/teritori/docker-compose.yml
+++ b/teritori/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.34-teritori-v1.3.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.34-teritori-v1.4.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
The proposal targets the upgrade proposal block to be 3699425, anticipated to be on June 7th 2023 at 14:00 UTC.

Useful links:
- https://www.mintscan.io/teritori/blocks/3699425
- https://www.mintscan.io/teritori/proposals/34