### PR TITLE
Make COSMOVISOR_ENABLED and START_CMD work as intended

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,5 +190,4 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 COPY run.sh snapshot.sh /usr/bin/
 RUN chmod +x /usr/bin/run.sh /usr/bin/snapshot.sh
 ENTRYPOINT ["run.sh"]
-
-CMD $START_CMD
+CMD []

--- a/run.sh
+++ b/run.sh
@@ -318,6 +318,8 @@ fi
 
 if [ -n "$SNAPSHOT_PATH" ]; then
   exec snapshot.sh "$START_CMD"
+elif [ -n "$START_CMD" ]; then
+  exec $START_CMD
 else
   exec "$@"
 fi

--- a/run.sh
+++ b/run.sh
@@ -323,5 +323,5 @@ if [ "$#" -ne 0 ]; then
 elif [ -n "$START_CMD" ]; then
   exec $PREFIX_CMD $START_CMD
 else
-  exec $PREFIX_CMD start
+  exec $PREFIX_CMD $PROJECT_BIN start
 fi

--- a/run.sh
+++ b/run.sh
@@ -23,9 +23,11 @@ export PROJECT_BIN="${PROJECT_BIN:-$PROJECT}"
 export PROJECT_DIR="${PROJECT_DIR:-.$PROJECT_BIN}"
 export CONFIG_DIR="${CONFIG_DIR:-config}"
 if [ "$COSMOVISOR_ENABLED" == "1" ]; then
-  export START_CMD="${START_CMD:-cosmovisor run start}"
+  PREFIX_CMD="cosmovisor run"
+elif [ -n "$SNAPSHOT_PATH"  ]; then
+  PREFIX_CMD="snapshot.sh"
 else
-  export START_CMD="${START_CMD:-$PROJECT_BIN start}"
+  PREFIX_CMD=
 fi
 export PROJECT_ROOT="/root/$PROJECT_DIR"
 export CONFIG_PATH="${CONFIG_PATH:-$PROJECT_ROOT/$CONFIG_DIR}"
@@ -316,10 +318,10 @@ if [[ ! -f "$PROJECT_ROOT/data/priv_validator_state.json" ]]; then
   echo '{"height":"0","round":0,"step":0}' > "$PROJECT_ROOT/data/priv_validator_state.json"
 fi
 
-if [ -n "$SNAPSHOT_PATH" ]; then
-  exec snapshot.sh "$START_CMD"
+if [ "$#" -ne 0 ]; then
+  exec $PREFIX_CMD "$@"
 elif [ -n "$START_CMD" ]; then
-  exec $START_CMD
+  exec $PREFIX_CMD $START_CMD
 else
-  exec "$@"
+  exec $PREFIX_CMD start
 fi


### PR DESCRIPTION
Teach the run.sh to use START_CMD if set, even when SNAPSHOT_PATH is unused (previously, it would exec whatever command line passed to the docker, or do nothing if none).

This also fixes the case of COSMOVISOR_ENABLED=1, which sets START_CMD to start cosmovisor but then was not actually run before.