### PR TITLE
Update Injective to v1.11.4-1686608669

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
           - project: impacthub
             version: v0.18.1
           - project: injective
-            version: v1.11.3-1686246472
+            version: v1.11.4-1686608669
           - project: irisnet
             version: v2.0.1
           - project: jackal

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,11 +122,8 @@ FROM gcc:12 AS zstd_build
 ARG ZTSD_SOURCE_URL="https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"
 
 RUN apt-get update && \
-      apt-get install --no-install-recommends --assume-yes python3 ninja-build && \
+      apt-get install --no-install-recommends --assume-yes python3 meson ninja-build && \
       apt-get clean && \
-    curl -o /tmp/get-pip.py -L 'https://bootstrap.pypa.io/get-pip.py' && \
-      python3 /tmp/get-pip.py && \
-    pip3 install meson && \
     mkdir -p /tmp/zstd && \
     cd /tmp/zstd && \
     curl -Lo zstd.source $ZTSD_SOURCE_URL && \

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[fetchhub](https://github.com/fetchai/fetchd)|`v0.10.6`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.35-fetchhub-v0.10.6`|[Example](./fetchhub)|
 |[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.7.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.35-gravitybridge-v1.7.2`|[Example](./gravitybridge)|
 |[impacthub](https://github.com/ixofoundation/ixo-blockchain)|`v0.18.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.35-impacthub-v0.18.1`|[Example](./impacthub)|
-|[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.11.3-1686246472`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.35-injective-v1.11.3-1686246472`|[Example](./injective)|
+|[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.11.4-1686608669`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.35-injective-v1.11.4-1686608669`|[Example](./injective)|
 |[irisnet](https://github.com/irisnet/irishub)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.35-irisnet-v2.0.1`|[Example](./irisnet)|
 |[jackal](https://github.com/JackalLabs/canine-chain)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.35-jackal-v2.0.1`|[Example](./jackal)|
 |[juno](https://github.com/CosmosContracts/Juno)|`v15.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.35-juno-v15.0.0`|[Example](./juno)|

--- a/injective/README.md
+++ b/injective/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.11.3-1686246472`|
+|Version|`v1.11.4-1686608669`|
 |Binary|`injectived`|
 |Directory|`.injectived`|
 |ENV namespace|`INJECTIVED`|
 |Repository|`https://github.com/InjectiveLabs/injective-chain-releases`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.35-injective-v1.11.3-1686246472`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.35-injective-v1.11.4-1686608669`|
 
 ## Examples
 

--- a/injective/build.yml
+++ b/injective/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: injective
         PROJECT_BIN: injectived
         PROJECT_DIR: .injectived
-        VERSION: v1.11.3-1686246472
+        VERSION: v1.11.4-1686608669
         BUILD_IMAGE: injective
     ports:
       - '26656:26656'

--- a/injective/deploy.yml
+++ b/injective/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.35-injective-v1.11.3-1686246472
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.35-injective-v1.11.4-1686608669
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/chain.json

--- a/injective/docker-compose.yml
+++ b/injective/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.35-injective-v1.11.3-1686246472
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.35-injective-v1.11.4-1686608669
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Also changes how `meson` is installed for the `zstd` build, since pip3 install method had started failing preventing image builds