### PR TITLE
Update Injective to v1.11.5-1687535916

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
           - project: impacthub
             version: v0.18.1
           - project: injective
-            version: v1.11.4-1686608669
+            version: v1.11.5-1687535916
           - project: irisnet
             version: v2.0.1
           - project: jackal

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[fetchhub](https://github.com/fetchai/fetchd)|`v0.10.6`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.36-fetchhub-v0.10.6`|[Example](./fetchhub)|
 |[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.7.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.36-gravitybridge-v1.7.2`|[Example](./gravitybridge)|
 |[impacthub](https://github.com/ixofoundation/ixo-blockchain)|`v0.18.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.36-impacthub-v0.18.1`|[Example](./impacthub)|
-|[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.11.4-1686608669`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.36-injective-v1.11.4-1686608669`|[Example](./injective)|
+|[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.11.5-1687535916`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.36-injective-v1.11.5-1687535916`|[Example](./injective)|
 |[irisnet](https://github.com/irisnet/irishub)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.36-irisnet-v2.0.1`|[Example](./irisnet)|
 |[jackal](https://github.com/JackalLabs/canine-chain)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.36-jackal-v2.0.1`|[Example](./jackal)|
 |[juno](https://github.com/CosmosContracts/Juno)|`v15.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.36-juno-v15.0.0`|[Example](./juno)|

--- a/injective/README.md
+++ b/injective/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.11.4-1686608669`|
+|Version|`v1.11.5-1687535916`|
 |Binary|`injectived`|
 |Directory|`.injectived`|
 |ENV namespace|`INJECTIVED`|
 |Repository|`https://github.com/InjectiveLabs/injective-chain-releases`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.36-injective-v1.11.4-1686608669`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.36-injective-v1.11.5-1687535916`|
 
 ## Examples
 

--- a/injective/build.yml
+++ b/injective/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: injective
         PROJECT_BIN: injectived
         PROJECT_DIR: .injectived
-        VERSION: v1.11.4-1686608669
+        VERSION: v1.11.5-1687535916
         BUILD_IMAGE: injective
     ports:
       - '26656:26656'

--- a/injective/deploy.yml
+++ b/injective/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.36-injective-v1.11.4-1686608669
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.36-injective-v1.11.5-1687535916
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/chain.json

--- a/injective/docker-compose.yml
+++ b/injective/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.36-injective-v1.11.4-1686608669
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.36-injective-v1.11.5-1687535916
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Pre-release: `ghcr.io/akash-network/cosmos-omnibus:v0.3.37-rc4-injective-v1.11.5-1687535916`