### PR TITLE
Update Jackal to v2.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,7 @@ jobs:
           - project: irisnet
             version: v2.0.1
           - project: jackal
-            version: v2.0.1
+            version: v2.1.0
           - project: juno
             version: v15.0.0
           - project: kava

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[impacthub](https://github.com/ixofoundation/ixo-blockchain)|`v0.18.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.39-impacthub-v0.18.1`|[Example](./impacthub)|
 |[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.11.5-1687535916`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.39-injective-v1.11.5-1687535916`|[Example](./injective)|
 |[irisnet](https://github.com/irisnet/irishub)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.39-irisnet-v2.0.1`|[Example](./irisnet)|
-|[jackal](https://github.com/JackalLabs/canine-chain)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.39-jackal-v2.0.1`|[Example](./jackal)|
+|[jackal](https://github.com/JackalLabs/canine-chain)|`v2.1.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.39-jackal-v2.1.0`|[Example](./jackal)|
 |[juno](https://github.com/CosmosContracts/Juno)|`v15.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.39-juno-v15.0.0`|[Example](./juno)|
 |[kava](https://github.com/Kava-Labs/kava)|`v0.23.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.39-kava-v0.23.1`|[Example](./kava)|
 |[kichain](https://github.com/KiFoundation/ki-tools)|`5.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.39-kichain-5.0.1`|[Example](./kichain)|

--- a/jackal/README.md
+++ b/jackal/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v2.0.1`|
+|Version|`v2.1.0`|
 |Binary|`canined`|
 |Directory|`.canine`|
 |ENV namespace|`CANINED`|
 |Repository|`https://github.com/JackalLabs/canine-chain`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.39-jackal-v2.0.1`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.39-jackal-v2.1.0`|
 
 ## Examples
 

--- a/jackal/build.yml
+++ b/jackal/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: jackal
         PROJECT_BIN: canined
-        VERSION: v2.0.1
+        VERSION: v2.1.0
         REPOSITORY: https://github.com/JackalLabs/canine-chain
         NAMESPACE: CANINED
         PROJECT_DIR: .canine

--- a/jackal/deploy.yml
+++ b/jackal/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.39-jackal-v2.0.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.39-jackal-v2.1.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_ID=jackal-1

--- a/jackal/docker-compose.yml
+++ b/jackal/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.39-jackal-v2.0.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.39-jackal-v2.1.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Proposal: https://explorer.nodestake.top/jackal/gov/8
Image: `ghcr.io/akash-network/cosmos-omnibus:v0.3.40-rc1-jackal-v2.1.0`

Resolves #579 