### PR TITLE
Fix regression for the case of COSMOVISOR_ENABLED without START_CMD

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -24,10 +24,13 @@ export PROJECT_DIR="${PROJECT_DIR:-.$PROJECT_BIN}"
 export CONFIG_DIR="${CONFIG_DIR:-config}"
 if [ "$COSMOVISOR_ENABLED" == "1" ]; then
   PREFIX_CMD="cosmovisor run"
+  DEFAULT_CMD=""
 elif [ -n "$SNAPSHOT_PATH"  ]; then
   PREFIX_CMD="snapshot.sh"
+  DEFAULT_CMD="$PROJECT_BIN"
 else
   PREFIX_CMD=
+  DEFAULT_CMD="$PROJECT_BIN"
 fi
 export PROJECT_ROOT="/root/$PROJECT_DIR"
 export CONFIG_PATH="${CONFIG_PATH:-$PROJECT_ROOT/$CONFIG_DIR}"
@@ -353,10 +356,12 @@ if [[ ! -f "$PROJECT_ROOT/data/priv_validator_state.json" ]]; then
   echo '{"height":"0","round":0,"step":0}' > "$PROJECT_ROOT/data/priv_validator_state.json"
 fi
 
+# use command line args if explicit given, else START_CMD if explicitly set,
+# or else DEFAULT_CMD (as set for the selecetd PREFIX_CMD).
 if [ "$#" -ne 0 ]; then
   exec $PREFIX_CMD "$@"
 elif [ -n "$START_CMD" ]; then
   exec $PREFIX_CMD $START_CMD
 else
-  exec $PREFIX_CMD $PROJECT_BIN start
+  exec $PREFIX_CMD $DEFAULT_CMD start
 fi


### PR DESCRIPTION
This fixes a glitch in commit 3aacc3485f8981008f21e3251cc9b2f4300d73df.

When starting without args and without START_CMD, the command for regular (as-is) and snapshot are "$PREFIX_CMD $PROJECT_BIN start", whereas for cosmovisor it should be "$PREFIX_CMD start".

Fix using a new DEFAULT_CMD that is set together with PREFIX_CMD based on the selected mode.