### PR TITLE
Fix START_CMD implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,16 @@ The node binary can be downloaded at runtime when using the [Generic image](#gen
 |`PROJECT_BIN`|Binary name|`$PROJECT`|`osmosisd`|
 |`PROJECT_DIR`|Name of project directory|`.$PROJECT_BIN`|`.osmosisd`|
 
+### Cosmovisor
+
+[Cosmovisor](https://docs.cosmos.network/main/tooling/cosmovisor) can be downloaded at runtime to automatically manage chain upgrades. You should be familiar with how Cosmovisor works before using this feature.
+
+|Variable|Description|Default|Examples|
+|---|---|---|---|
+|`COSMOVISOR_ENABLED`|Enable Cosmovisor binary download and support| |`1`|
+|`COSMOVISOR_VERSION`|Version of Cosmovisor to download|`1.3.0`| |
+|`COSMOVISOR_URL`|Alternative full URL to Cosmovisor binary tar.gz| | |
+
 ### Shortcuts
 
 See [Cosmos docs](https://docs.tendermint.com/master/nodes/configuration.html) for more information


### PR DESCRIPTION
Adjusts the `START_CMD` implementation so that:

- Docker command takes precedence if set
- Next is `START_CMD` arg/env variable if set
- Otherwise `cosmovisor run start` if `COSMOVISOR_ENABLED`
- Otherwise `$PROJECT_BIN start`
- `snapshot.sh` script is always used if `SNAPSHOT_PATH` is set, with the command it runs set by the above logic

Also documents Cosmovisor support in the README, and adds a bit more logging so it's clear what's happening.

I considered adding a `SNAPSHOT_ENABLED` env instead of implicitly enabling with `SNAPSHOT_PATH`, but decided not to change that yet.