### PR TITLE
Update Lum network to 1.5.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
           - project: likecoin
             version: v4.0.1
           - project: lumnetwork
-            version: v1.4.5
+            version: v1.5.1
           - project: mars
             version: v1.0.2
           - project: migaloo

--- a/lumnetwork/README.md
+++ b/lumnetwork/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.4.5`|
+|Version|`v1.5.1`|
 |Binary|`lumd`|
 |Directory|`.lumd`|
 |ENV namespace|`LUMD`|
 |Repository|`https://github.com/lum-network/chain`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.42-lumnetwork-v1.4.5`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.42-lumnetwork-v1.5.1`|
 
 ## Examples
 

--- a/lumnetwork/build.yml
+++ b/lumnetwork/build.yml
@@ -8,9 +8,10 @@ services:
         PROJECT: lum
         PROJECT_BIN: lumd
         PROJECT_DIR: .lumd
-        VERSION: v1.4.5
+        VERSION: v1.5.1
         REPOSITORY: https://github.com/lum-network/chain
         NAMESPACE: LUMD
+        GOLANG_VERSION: 1.19.7-buster
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/lumnetwork/deploy.yml
+++ b/lumnetwork/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.42-lumnetwork-v1.4.5
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.42-lumnetwork-v1.5.1
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/chain.json

--- a/lumnetwork/docker-compose.yml
+++ b/lumnetwork/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.42-lumnetwork-v1.4.5
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.42-lumnetwork-v1.5.1
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
More details:
- https://www.mintscan.io/lum/proposals/82
- Upgrade to v1.5.1 is scheduled for block #8527300 on Monday, July 24th around 18:00 UTC.