### PR TITLE
Upgrade Osmosis to v19.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
           - project: omniflixhub
             version: v0.12.0
           - project: osmosis
-            version: v18.0.0
+            version: v19.0.0
           - project: panacea
             version: v2.0.5
           - project: passage

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[neutron](https://github.com/neutron-org/neutron)|`v1.0.4`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-neutron-v1.0.4`|[Example](./neutron)|
 |[nois](https://github.com/noislabs/noisd)|`v1.0.4`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-nois-v1.0.4`|[Example](./nois)|
 |[omniflixhub](https://github.com/OmniFlix/omniflixhub)|`v0.12.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-omniflixhub-v0.12.0`|[Example](./omniflixhub)|
-|[osmosis](https://github.com/osmosis-labs/osmosis)|`v18.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-osmosis-v18.0.0`|[Example](./osmosis)|
+|[osmosis](https://github.com/osmosis-labs/osmosis)|`v19.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-osmosis-v19.0.0`|[Example](./osmosis)|
 |[panacea](https://github.com/medibloc/panacea-core)|`v2.0.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-panacea-v2.0.5`|[Example](./panacea)|
 |[passage](https://github.com/envadiv/Passage3D)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-passage-v2.0.1`|[Example](./passage)|
 |[persistence](https://github.com/persistenceOne/persistenceCore)|`v3.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-persistence-v3.2.0`|[Example](./persistence)|

--- a/osmosis/README.md
+++ b/osmosis/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v18.0.0`|
+|Version|`v19.0.0`|
 |Binary|`osmosisd`|
 |Directory|`.osmosisd`|
 |ENV namespace|`OSMOSISD`|
 |Repository|`https://github.com/omosis-labs/osmosis`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-osmosis-v18.0.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-osmosis-v19.0.0`|
 
 ## Examples
 

--- a/osmosis/build.yml
+++ b/osmosis/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: osmosis
         PROJECT_BIN: osmosisd
-        VERSION: v18.0.0
+        VERSION: v19.0.0
         REPOSITORY: https://github.com/osmosis-labs/osmosis
         NAMESPACE: OSMOSISD
         GOLANG_VERSION: 1.20-buster

--- a/osmosis/deploy.yml
+++ b/osmosis/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.46-osmosis-v18.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.46-osmosis-v19.0.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/chain.json

--- a/osmosis/docker-compose.yml
+++ b/osmosis/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.46-osmosis-v18.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.46-osmosis-v19.0.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
This upgrade is governed by Proposal 606, which aims to upgrade the Osmosis codebase to the v19.0.0 software tag at block height 11317300. This is estimated to occur on Tuesday, September 5th, at UTC 16:00.