### PR TITLE
Upgrade persistence to v9.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,7 @@ jobs:
           - project: passage
             version: v2.0.1
           - project: persistence
-            version: v3.2.0
+            version: v9.1.1
           - project: regen
             version: v5.1.1
           - project: rizon

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[osmosis](https://github.com/osmosis-labs/osmosis)|`v18.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-osmosis-v18.0.0`|[Example](./osmosis)|
 |[panacea](https://github.com/medibloc/panacea-core)|`v2.0.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-panacea-v2.0.5`|[Example](./panacea)|
 |[passage](https://github.com/envadiv/Passage3D)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-passage-v2.0.1`|[Example](./passage)|
-|[persistence](https://github.com/persistenceOne/persistenceCore)|`v3.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-persistence-v3.2.0`|[Example](./persistence)|
+|[persistence](https://github.com/persistenceOne/persistenceCore)|`v9.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-persistence-v9.1.1`|[Example](./persistence)|
 |[regen](https://github.com/regen-network/regen-ledger)|`v5.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-regen-v5.1.1`|[Example](./regen)|
 |[rizon](https://github.com/rizon-world/rizon)|`v0.4.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-rizon-v0.4.1`|[Example](./rizon)|
 |[seinetwork](https://github.com/sei-protocol/sei-chain)|`1.2.2beta-postfix`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-seinetwork-1.2.2beta-postfix`|[Example](./seinetwork)|

--- a/persistence/README.md
+++ b/persistence/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v3.2.0`|
+|Version|`v9.1.1`|
 |Binary|`persistenceCore`|
 |Directory|`.persistenceCore`|
 |ENV namespace|`PERSISTENCECORE`|
 |Repository|`https://github.com/persistenceOne/persistenceCore`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-persistence-v3.2.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.46-persistence-v9.1.1`|
 
 ## Examples
 

--- a/persistence/build.yml
+++ b/persistence/build.yml
@@ -7,9 +7,10 @@ services:
       args:
         PROJECT: persistence
         PROJECT_BIN: persistenceCore
-        VERSION: v3.2.0
+        VERSION: v9.1.1
         REPOSITORY: https://github.com/persistenceOne/persistenceCore
         NAMESPACE: PERSISTENCECORE
+        GOLANG_VERSION: 1.20-buster
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/persistence/deploy.yml
+++ b/persistence/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.46-persistence-v3.2.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.46-persistence-v9.1.1
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/chain.json

--- a/persistence/docker-compose.yml
+++ b/persistence/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.46-persistence-v3.2.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.46-persistence-v9.1.1
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Peristence will be upgraded to v9.1.1 at block 13160000.

https://www.mintscan.io/persistence/blocks/13160000 Estimated Time:  Sep 13th 2023, 12:12:42

Proposal: https://www.mintscan.io/persistence/proposals/43