### PR TITLE
Upgrade Migaloo to v3.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,7 @@ jobs:
           - project: mars
             version: v1.0.2
           - project: migaloo
-            version: v2.2.6
+            version: v3.0.0
           - project: neutron
             version: v1.0.4
           - project: nois

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,7 @@ jobs:
           - project: mars
             version: v1.0.2
           - project: migaloo
-            version: v3.0.0
+            version: v3.0.1-hotfix
           - project: neutron
             version: v1.0.4
           - project: nois

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[likecoin](https://github.com/likecoin/likecoin-chain)|`v4.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-likecoin-v4.0.1`|[Example](./likecoin)|
 |[lumnetwork](https://github.com/lum-network/chain)|`v1.5.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-lumnetwork-v1.5.2`|[Example](./lumnetwork)|
 |[mars](https://github.com/mars-protocol/hub.git)|`v1.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-mars-v1.0.2`|[Example](./mars)|
-|[migaloo](https://github.com/White-Whale-Defi-Platform/migaloo-chain)|`v3.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.0`|[Example](./migaloo)|
+|[migaloo](https://github.com/White-Whale-Defi-Platform/migaloo-chain)|`v3.0.1-hotfix`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.1-hotfix`|[Example](./migaloo)|
 |[neutron](https://github.com/neutron-org/neutron)|`v1.0.4`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-neutron-v1.0.4`|[Example](./neutron)|
 |[nois](https://github.com/noislabs/noisd)|`v1.0.4`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-nois-v1.0.4`|[Example](./nois)|
 |[omniflixhub](https://github.com/OmniFlix/omniflixhub)|`v0.12.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-omniflixhub-v0.12.0`|[Example](./omniflixhub)|

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[likecoin](https://github.com/likecoin/likecoin-chain)|`v4.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-likecoin-v4.0.1`|[Example](./likecoin)|
 |[lumnetwork](https://github.com/lum-network/chain)|`v1.5.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-lumnetwork-v1.5.2`|[Example](./lumnetwork)|
 |[mars](https://github.com/mars-protocol/hub.git)|`v1.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-mars-v1.0.2`|[Example](./mars)|
-|[migaloo](https://github.com/White-Whale-Defi-Platform/migaloo-chain)|`v2.2.6`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v2.2.6`|[Example](./migaloo)|
+|[migaloo](https://github.com/White-Whale-Defi-Platform/migaloo-chain)|`v3.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.0`|[Example](./migaloo)|
 |[neutron](https://github.com/neutron-org/neutron)|`v1.0.4`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-neutron-v1.0.4`|[Example](./neutron)|
 |[nois](https://github.com/noislabs/noisd)|`v1.0.4`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-nois-v1.0.4`|[Example](./nois)|
 |[omniflixhub](https://github.com/OmniFlix/omniflixhub)|`v0.12.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-omniflixhub-v0.12.0`|[Example](./omniflixhub)|

--- a/migaloo/README.md
+++ b/migaloo/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v2.2.6`|
+|Version|`v3.0.0`|
 |Binary|`migalood`|
 |Directory|`.migalood`|
 |ENV namespace|`MIGALOOD`|
 |Repository|`https://github.com/White-Whale-Defi-Platform/migaloo-chain`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v2.2.6`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.0`|
 
 ## Examples
 

--- a/migaloo/README.md
+++ b/migaloo/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v3.0.0`|
+|Version|`v3.0.1-hotfix`|
 |Binary|`migalood`|
 |Directory|`.migalood`|
 |ENV namespace|`MIGALOOD`|
 |Repository|`https://github.com/White-Whale-Defi-Platform/migaloo-chain`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.1-hotfix`|
 
 ## Examples
 

--- a/migaloo/build.yml
+++ b/migaloo/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: migaloo
         PROJECT_BIN: migalood
-        VERSION: v3.0.0
+        VERSION: v3.0.1-hotfix
         REPOSITORY: https://github.com/White-Whale-Defi-Platform/migaloo-chain
         NAMESPACE: MIGALOOD
         PROJECT_DIR: .migalood

--- a/migaloo/build.yml
+++ b/migaloo/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: migaloo
         PROJECT_BIN: migalood
-        VERSION: v2.2.6
+        VERSION: v3.0.0
         REPOSITORY: https://github.com/White-Whale-Defi-Platform/migaloo-chain
         NAMESPACE: MIGALOOD
         PROJECT_DIR: .migalood

--- a/migaloo/deploy.yml
+++ b/migaloo/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.1-hotfix
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/chain.json

--- a/migaloo/deploy.yml
+++ b/migaloo/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v2.2.6
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/chain.json

--- a/migaloo/docker-compose.yml
+++ b/migaloo/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.1-hotfix
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/migaloo/docker-compose.yml
+++ b/migaloo/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v2.2.6
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.49-migaloo-v3.0.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Migaloo will be upgraded to v3.0.0 at block 3574316.

Details:
- https://migaloo.explorers.guru/block/3574316
- Estimated date: 09.10.2023, 16:43:19

Proposal: https://migaloo.explorers.guru/proposal/13