### PR TITLE
Upgrade stride to v16.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,7 +127,7 @@ jobs:
           - project: stargaze
             version: v12.0.0
           - project: stride
-            version: v15.0.0
+            version: v16.0.0
           - project: starname
             version: v0.11.5
           - project: teritori

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[sommelier](https://github.com/PeggyJV/sommelier)|`v4.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-sommelier-v4.0.2`|[Example](./sommelier)|
 |[stargaze](https://github.com/public-awesome/stargaze)|`v12.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-stargaze-v12.0.0`|[Example](./stargaze)|
 |[starname](https://github.com/iov-one/starnamed)|`v0.11.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-starname-v0.11.5`|[Example](./starname)|
-|[stride](https://github.com/Stride-Labs/stride)|`v15.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-stride-v15.0.0`|[Example](./stride)|
+|[stride](https://github.com/Stride-Labs/stride)|`v16.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-stride-v16.0.0`|[Example](./stride)|
 |[teritori](https://github.com/TERITORI/teritori-chain)|`v1.4.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-teritori-v1.4.0`|[Example](./teritori)|
 |[umee](https://github.com/umee-network/umee)|`v3.1.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-umee-v3.1.0`|[Example](./umee)|
 |[ununifi](https://github.com/UnUniFi/chain)|`v3.2.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-ununifi-v3.2.2`|[Example](./ununifi)|

--- a/stride/README.md
+++ b/stride/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v15.0.0`|
+|Version|`v16.0.0`|
 |Binary|`strided`|
 |Directory|`.stride`|
 |ENV namespace|`STRIDED`|
 |Repository|`https://github.com/Stride-Labs/stride`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-stride-v15.0.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-stride-v16.0.0`|
 
 ## Examples
 

--- a/stride/build.yml
+++ b/stride/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: stride
         PROJECT_BIN: strided
-        VERSION: v15.0.0
+        VERSION: v16.0.0
         REPOSITORY: https://github.com/Stride-Labs/stride
         NAMESPACE: STRIDED
         PROJECT_DIR: .stride

--- a/stride/deploy.yml
+++ b/stride/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-stride-v15.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-stride-v16.0.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/chain.json

--- a/stride/docker-compose.yml
+++ b/stride/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-stride-v15.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-stride-v16.0.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Stride will be updated to v16.0.0 at block https://dev.mintscan.io/stride/blocks/5932395

Estimated Target Date: Wed Oct 18 2023 14:39:09 GMT+0200 (GMT+02:00)

Proposal: https://dev.mintscan.io/stride/proposals/220