### PR TITLE
Upgrade passage to v2.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
           - project: panacea
             version: v2.0.5
           - project: passage
-            version: v2.0.1
+            version: v2.2.0
           - project: persistence
             version: v9.1.1
           - project: regen

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[omniflixhub](https://github.com/OmniFlix/omniflixhub)|`v0.12.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-omniflixhub-v0.12.0`|[Example](./omniflixhub)|
 |[osmosis](https://github.com/osmosis-labs/osmosis)|`v19.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-osmosis-v19.0.0`|[Example](./osmosis)|
 |[panacea](https://github.com/medibloc/panacea-core)|`v2.0.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-panacea-v2.0.5`|[Example](./panacea)|
-|[passage](https://github.com/envadiv/Passage3D)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-passage-v2.0.1`|[Example](./passage)|
+|[passage](https://github.com/envadiv/Passage3D)|`v2.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-passage-v2.2.0`|[Example](./passage)|
 |[persistence](https://github.com/persistenceOne/persistenceCore)|`v9.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-persistence-v9.1.1`|[Example](./persistence)|
 |[regen](https://github.com/regen-network/regen-ledger)|`v5.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-regen-v5.1.1`|[Example](./regen)|
 |[rizon](https://github.com/rizon-world/rizon)|`v0.4.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-rizon-v0.4.1`|[Example](./rizon)|

--- a/passage/README.md
+++ b/passage/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v2.0.1`|
+|Version|`v2.2.0`|
 |Binary|`passage`|
 |Directory|`.passage`|
 |ENV namespace|`PASSAGE`|
 |Repository|`https://github.com/envadiv/Passage3D`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-passage-v2.0.1`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-passage-v2.2.0`|
 
 ## Examples
 

--- a/passage/build.yml
+++ b/passage/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: passage
         PROJECT_BIN: passage
-        VERSION: v2.0.1
+        VERSION: v2.2.0
         REPOSITORY: https://github.com/envadiv/Passage3D
         NAMESPACE: PASSAGE
         PROJECT_DIR: .passage

--- a/passage/deploy.yml
+++ b/passage/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-passage-v2.0.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-passage-v2.2.0
     env:
       - MONIKER=my-moniker-1
       # - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/passage/chain.json

--- a/passage/docker-compose.yml
+++ b/passage/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-passage-v2.0.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-passage-v2.2.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Passage will be upgraded to v2.2.0 at block https://dev.mintscan.io/passage/blocks/5288888

Estimated Target Date: Sun Oct 22 2023 07:20:35 GMT+0200 (GMT+02:00)

Proposal: https://dev.mintscan.io/passage/proposals/5