### PR TITLE
Upgrade persistence to v10.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
           - project: passage
             version: v2.0.1
           - project: persistence
-            version: v9.1.1
+            version: v10.0.0
           - project: regen
             version: v5.1.1
           - project: rizon

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[osmosis](https://github.com/osmosis-labs/osmosis)|`v19.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-osmosis-v19.0.0`|[Example](./osmosis)|
 |[panacea](https://github.com/medibloc/panacea-core)|`v2.0.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-panacea-v2.0.5`|[Example](./panacea)|
 |[passage](https://github.com/envadiv/Passage3D)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-passage-v2.0.1`|[Example](./passage)|
-|[persistence](https://github.com/persistenceOne/persistenceCore)|`v9.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-persistence-v9.1.1`|[Example](./persistence)|
+|[persistence](https://github.com/persistenceOne/persistenceCore)|`v10.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-persistence-v10.0.0`|[Example](./persistence)|
 |[regen](https://github.com/regen-network/regen-ledger)|`v5.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-regen-v5.1.1`|[Example](./regen)|
 |[rizon](https://github.com/rizon-world/rizon)|`v0.4.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-rizon-v0.4.1`|[Example](./rizon)|
 |[seinetwork](https://github.com/sei-protocol/sei-chain)|`1.2.2beta-postfix`|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-seinetwork-1.2.2beta-postfix`|[Example](./seinetwork)|

--- a/persistence/README.md
+++ b/persistence/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v9.1.1`|
+|Version|`v10.0.0`|
 |Binary|`persistenceCore`|
 |Directory|`.persistenceCore`|
 |ENV namespace|`PERSISTENCECORE`|
 |Repository|`https://github.com/persistenceOne/persistenceCore`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-persistence-v9.1.1`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.3.51-persistence-v10.0.0`|
 
 ## Examples
 

--- a/persistence/build.yml
+++ b/persistence/build.yml
@@ -7,10 +7,10 @@ services:
       args:
         PROJECT: persistence
         PROJECT_BIN: persistenceCore
-        VERSION: v9.1.1
+        VERSION: v10.0.0
         REPOSITORY: https://github.com/persistenceOne/persistenceCore
         NAMESPACE: PERSISTENCECORE
-        GOLANG_VERSION: 1.20-buster
+        GOLANG_VERSION: 1.21-bullseye
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/persistence/deploy.yml
+++ b/persistence/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-persistence-v9.1.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-persistence-v10.0.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/chain.json

--- a/persistence/docker-compose.yml
+++ b/persistence/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-persistence-v9.1.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.3.51-persistence-v10.0.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Persistence will be upgraded to v10.0.0 at block https://dev.mintscan.io/persistence/blocks/13870350

Estimated Target Date: Thu Nov 02 2023 15:27:02 GMT+0100 (GMT+01:00)

Proposal: https://dev.mintscan.io/persistence/proposals/55