### PR TITLE
feat(run): auto-detect PROJECT from CHAIN JSON via PROJECT_BIN

### DIFF
--- a/generic/build.yml
+++ b/generic/build.yml
@@ -12,8 +12,9 @@ services:
       - '1317:1317'
     environment:
       - MONIKER=node_1
-      - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/main/edgenet/meta.json
-      - BINARY_ZIP_PATH=akash_0.15.0-rc14_linux_amd64/akash
+      - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/main/mainnet/meta.json
+      - P2P_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     env_file:
       - ../.env
     volumes:

--- a/generic/deploy.yml
+++ b/generic/deploy.yml
@@ -6,8 +6,9 @@ services:
     image: ghcr.io/akash-network/cosmos-omnibus:v0.4.0-generic
     env:
       - MONIKER=my-moniker-1
-      - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/main/edgenet/meta.json
-      - BINARY_ZIP_PATH=akash_0.15.0-rc14_linux_amd64/akash
+      - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/main/mainnet/meta.json
+      - P2P_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     expose:
       - port: 26657
         as: 80

--- a/generic/docker-compose.yml
+++ b/generic/docker-compose.yml
@@ -9,7 +9,8 @@ services:
       - '1317:1317'
     environment:
       - MONIKER=node_1
-      - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/main/edgenet/meta.json
-      - BINARY_ZIP_PATH=akash_0.15.0-rc14_linux_amd64/akash
+      - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/main/mainnet/meta.json
+      - P2P_POLKACHU=1
+      - STATESYNC_POLKACHU=1
     volumes:
       - ./node-data:/root/.akash

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,7 @@ if [ -n "$CHAIN_JSON" ]; then
   export P2P_PERSISTENT_PEERS="${P2P_PERSISTENT_PEERS:-$(echo $CHAIN_METADATA | jq -r '.peers.persistent_peers | map(.id+"@"+.address) | join(",")')}"
   export GENESIS_URL="${GENESIS_URL:-$(echo $CHAIN_METADATA | jq -r '.codebase.genesis.genesis_url? // .genesis.genesis_url? // .genesis?')}"
   export BINARY_URL="${BINARY_URL:-$(echo $CHAIN_METADATA | jq -r '.codebase.binaries."linux/amd64"?')}"
+  export PROJECT="${PROJECT:-$(echo $CHAIN_METADATA | jq -r '.chain_name?')}"
   export PROJECT_BIN="${PROJECT_BIN:-$(echo $CHAIN_METADATA | jq -r '.codebase.daemon_name? // .daemon_name?')}"
   if [ -z "$PROJECT_DIR" ]; then
     FULL_DIR=$(echo $CHAIN_METADATA | jq -r '.codebase.node_home? // .node_home?')
@@ -19,7 +20,6 @@ if [ -n "$CHAIN_JSON" ]; then
   fi
 fi
 
-export PROJECT="${PROJECT:-$PROJECT_BIN}"
 export PROJECT_BIN="${PROJECT_BIN:-$PROJECT}"
 export PROJECT_DIR="${PROJECT_DIR:-.$PROJECT_BIN}"
 export CONFIG_DIR="${CONFIG_DIR:-config}"

--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,7 @@ if [ -n "$CHAIN_JSON" ]; then
   fi
 fi
 
+export PROJECT="${PROJECT:-$PROJECT_BIN}"
 export PROJECT_BIN="${PROJECT_BIN:-$PROJECT}"
 export PROJECT_DIR="${PROJECT_DIR:-.$PROJECT_BIN}"
 export CONFIG_DIR="${CONFIG_DIR:-config}"


### PR DESCRIPTION
"generic" images do not include PROJECT which fails the run when `STATESYNC_POLKACHU=1`

Often people would use CHAIN JSON where PROJECT_BIN is known.
Let's attempt auto-detect the PROJECT based on the PROJECT_BIN value, unless PROJECT has already been set prior.