### PR TITLE
Upgrade gravitybridge to v1.11.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
           - project: gitopia
             version: v2.1.1
           - project: gravitybridge
-            version: v1.7.2
+            version: v1.11.1
           - project: impacthub
             version: v0.18.1
           - project: injective

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[evmos](https://github.com/evmos/evmos)|`v15.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-evmos-v15.0.0`|[Example](./evmos)|
 |[fetchhub](https://github.com/fetchai/fetchd)|`v0.10.6`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-fetchhub-v0.10.6`|[Example](./fetchhub)|
 |[gitopia](https://github.com/gitopia/gitopia)|`v2.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-gitopia-v2.1.1`|[Example](./gitopia)|
-|[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.7.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-gravitybridge-v1.7.2`|[Example](./gravitybridge)|
+|[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.11.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-gravitybridge-v1.11.1`|[Example](./gravitybridge)|
 |[impacthub](https://github.com/ixofoundation/ixo-blockchain)|`v0.18.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-impacthub-v0.18.1`|[Example](./impacthub)|
 |[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.11.6-1688984159`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-injective-v1.11.6-1688984159`|[Example](./injective)|
 |[irisnet](https://github.com/irisnet/irishub)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-irisnet-v2.0.1`|[Example](./irisnet)|

--- a/gravitybridge/README.md
+++ b/gravitybridge/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.7.2`|
+|Version|`v1.11.1`|
 |Binary|`gravity`|
 |Directory|`.gravity`|
 |ENV namespace|`GRAVITY`|
 |Repository|`https://github.com/Gravity-Bridge/Gravity-Bridge`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-gravitybridge-v1.7.2`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-gravitybridge-v1.11.1`|
 
 ## Examples
 

--- a/gravitybridge/build.yml
+++ b/gravitybridge/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: gravitybridge
         PROJECT_BIN: gravity
-        VERSION: v1.7.2
+        VERSION: v1.11.1
         BUILD_IMAGE: binary
         BINARY_URL: https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.7.2/gravity-linux-amd64
     ports:

--- a/gravitybridge/deploy.yml
+++ b/gravitybridge/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-gravitybridge-v1.7.2
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-gravitybridge-v1.11.1
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/chain.json

--- a/gravitybridge/docker-compose.yml
+++ b/gravitybridge/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-gravitybridge-v1.7.2
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-gravitybridge-v1.11.1
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Gravity Bridge will be updated to v1.11.1 at block https://dev.mintscan.io/gravity-bridge/blocks/9244100 Estimated Target Date: Wed Nov 15 2023 17:59:27 GMT+0100 (GMT+01:00)

Proposal: https://dev.mintscan.io/gravity-bridge/proposals/212