### PR TITLE
Upgrade Shentu to v2.9.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,7 +121,7 @@ jobs:
           - project: sentinel
             version: v0.11.3
           - project: shentu
-            version: v2.8.0
+            version: v2.9.0
           - project: sifchain
             version: v1.2.0-beta
           - project: sommelier

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[rizon](https://github.com/rizon-world/rizon)|`v0.4.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-rizon-v0.4.1`|[Example](./rizon)|
 |[seinetwork](https://github.com/sei-protocol/sei-chain)|`1.2.2beta-postfix`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-seinetwork-1.2.2beta-postfix`|[Example](./seinetwork)|
 |[sentinel](https://github.com/sentinel-official/hub)|`v0.11.3`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-sentinel-v0.11.3`|[Example](./sentinel)|
-|[shentu](https://github.com/certikfoundation/shentu)|`v2.8.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-shentu-v2.8.0`|[Example](./shentu)|
+|[shentu](https://github.com/certikfoundation/shentu)|`v2.9.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-shentu-v2.9.0`|[Example](./shentu)|
 |[sifchain](https://github.com/Sifchain/sifnode)|`v1.2.0-beta`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-sifchain-v1.2.0-beta`|[Example](./sifchain)|
 |[sommelier](https://github.com/PeggyJV/sommelier)|`v4.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-sommelier-v4.0.2`|[Example](./sommelier)|
 |[stargaze](https://github.com/public-awesome/stargaze)|`v12.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-stargaze-v12.0.0`|[Example](./stargaze)|

--- a/shentu/README.md
+++ b/shentu/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v2.8.0`|
+|Version|`v2.9.0`|
 |Binary|`shentud`|
 |Directory|`.shentud`|
 |ENV namespace|`SHENTUD`|
 |Repository|`https://github.com/shentufoundation/shentu`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-shentu-v2.8.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-shentu-v2.9.0`|
 
 ## Examples
 

--- a/shentu/build.yml
+++ b/shentu/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: shentu
         PROJECT_BIN: shentud
         PROJECT_DIR: .shentud
-        VERSION: v2.8.0
+        VERSION: v2.9.0
         REPOSITORY: https://github.com/shentufoundation/shentu/
         NAMESPACE: CERTIK
     ports:

--- a/shentu/deploy.yml
+++ b/shentu/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-shentu-v2.8.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-shentu-v2.9.0
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/chain.json

--- a/shentu/docker-compose.yml
+++ b/shentu/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-shentu-v2.8.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-shentu-v2.9.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Shentu will be upgraded to v2.9.0 at block https://dev.mintscan.io/shentu/blocks/16084500

Estimated Target Date: Tue Nov 28 2023 15:57:57 GMT+0100 (GMT+01:00)

Proposal: https://dev.mintscan.io/shentu/proposals/29