### PR TITLE
Update LikeCoin to v4.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
           - project: kyve
             version: v1.3.1
           - project: likecoin
-            version: v4.0.2
+            version: v4.1.1
           - project: lumnetwork
             version: v1.6.2
           - project: mars

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[konstellation](https://github.com/konstellation/konstellation)|`v0.5.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-konstellation-v0.5.0`|[Example](./konstellation)|
 |[kujira](https://github.com/Team-Kujira/core)|`v0.9.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-kujira-v0.9.1`|[Example](./kujira)|
 |[kyve](https://github.com/KYVENetwork/chain)|`v1.3.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-kyve-v1.3.1`|[Example](./kyve)|
-|[likecoin](https://github.com/likecoin/likecoin-chain)|`v4.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-likecoin-v4.0.2`|[Example](./likecoin)|
+|[likecoin](https://github.com/likecoin/likecoin-chain)|`v4.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-likecoin-v4.1.1`|[Example](./likecoin)|
 |[lumnetwork](https://github.com/lum-network/chain)|`v1.6.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-lumnetwork-v1.6.2`|[Example](./lumnetwork)|
 |[mars](https://github.com/mars-protocol/hub.git)|`v1.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-mars-v1.0.2`|[Example](./mars)|
 |[migaloo](https://github.com/White-Whale-Defi-Platform/migaloo-chain)|`v3.0.1-hotfix`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-migaloo-v3.0.1-hotfix`|[Example](./migaloo)|

--- a/likecoin/README.md
+++ b/likecoin/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v4.0.2`|
+|Version|`v4.1.1`|
 |Binary|`liked`|
 |Directory|`.liked`|
 |ENV namespace|`LIKED`|
 |Repository|`https://github.com/likecoin/likecoin-chain`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-likecoin-v4.0.2`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-likecoin-v4.1.1`|
 
 ## Examples
 

--- a/likecoin/build.yml
+++ b/likecoin/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: likecoin
         PROJECT_BIN: liked
-        VERSION: v4.0.2
+        VERSION: v4.1.1
         REPOSITORY: https://github.com/likecoin/likecoin-chain
         NAMESPACE: LIKED
         GOLANG_VERSION: 1.19-buster

--- a/likecoin/deploy.yml
+++ b/likecoin/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-likecoin-v4.0.2
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-likecoin-v4.1.1
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/chain.json

--- a/likecoin/docker-compose.yml
+++ b/likecoin/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-likecoin-v4.0.2
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-likecoin-v4.1.1
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
https://github.com/likecoin/likecoin-chain/releases/tag/v4.1.1

Software upgrade proposal: 
[dao.like.co](https://dao.like.co/proposals/77)
[Mintscan](https://www.mintscan.io/likecoin/proposals/77)
[BigDipper](https://bigdipper.live/likecoin/proposals/77)
[Ping Hub](https://ping.pub/likecoin/gov/77)