### PR TITLE
Upgrade Decentr to v1.6.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
           - project: cryptoorgchain
             version: v4.2.6
           - project: decentr
-            version: v1.6.2
+            version: v1.6.3
           - project: defund
             version: v0.1.0-alpha
           - project: desmos

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[crescent](https://github.com/crescent-network/crescent)|`v4.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-crescent-v4.2.0`|[Example](./crescent)|
 |[cronos](https://github.com/crypto-org-chain/cronos)|`v1.0.9`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-cronos-v1.0.9`|[Example](./cronos)|
 |[cryptoorgchain](https://github.com/crypto-org-chain/chain-main)|`v4.2.6`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-cryptoorgchain-v4.2.6`|[Example](./cryptoorgchain)|
-|[decentr](https://github.com/Decentr-net/decentr)|`v1.6.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-decentr-v1.6.2`|[Example](./decentr)|
+|[decentr](https://github.com/Decentr-net/decentr)|`v1.6.3`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-decentr-v1.6.3`|[Example](./decentr)|
 |[defund](https://github.com/defund-labs/defund)|`v0.1.0-alpha`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-defund-v0.1.0-alpha`|[Example](./defund)|
 |[desmos](https://github.com/desmos-labs/desmos)|`v4.8.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-desmos-v4.8.0`|[Example](./desmos)|
 |[dig](https://github.com/notional-labs/dig)|`v3.3.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-dig-v3.3.1`|[Example](./dig)|

--- a/decentr/README.md
+++ b/decentr/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.6.2`|
+|Version|`v1.6.3`|
 |Binary|`decentrd`|
 |Directory|`.decentr`|
 |ENV namespace|`decentr`|
 |Repository|`https://github.com/Decentr-net/decentr`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-decentr-v1.6.2`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.1-decentr-v1.6.3`|
 
 ## Examples
 

--- a/decentr/build.yml
+++ b/decentr/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: decentr
         PROJECT_BIN: decentrd
         PROJECT_DIR: .decentr
-        VERSION: v1.6.2
+        VERSION: v1.6.3
         REPOSITORY: https://github.com/Decentr-net/decentr
         NAMESPACE: DECENTRD
     ports:

--- a/decentr/deploy.yml
+++ b/decentr/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-decentr-v1.6.2
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-decentr-v1.6.3
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/chain.json

--- a/decentr/docker-compose.yml
+++ b/decentr/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-decentr-v1.6.2
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.1-decentr-v1.6.3
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Decentr has been upgraded to v1.6.3 at block 11619000.

https://ping.pub/decentr/block/11619000

Date and time: 20/11/2023, 18:09:37