### PR TITLE
Upgrade lumnetwork to v1.6.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
           - project: likecoin
             version: v4.0.2
           - project: lumnetwork
-            version: v1.6.2
+            version: v1.6.3
           - project: mars
             version: v1.0.2
           - project: migaloo

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[kujira](https://github.com/Team-Kujira/core)|`v0.9.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kujira-v0.9.1`|[Example](./kujira)|
 |[kyve](https://github.com/KYVENetwork/chain)|`v1.3.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kyve-v1.3.1`|[Example](./kyve)|
 |[likecoin](https://github.com/likecoin/likecoin-chain)|`v4.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-likecoin-v4.0.2`|[Example](./likecoin)|
-|[lumnetwork](https://github.com/lum-network/chain)|`v1.6.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-lumnetwork-v1.6.2`|[Example](./lumnetwork)|
+|[lumnetwork](https://github.com/lum-network/chain)|`v1.6.3`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-lumnetwork-v1.6.3`|[Example](./lumnetwork)|
 |[mars](https://github.com/mars-protocol/hub.git)|`v1.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-mars-v1.0.2`|[Example](./mars)|
 |[migaloo](https://github.com/White-Whale-Defi-Platform/migaloo-chain)|`v3.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-migaloo-v3.0.2`|[Example](./migaloo)|
 |[neutron](https://github.com/neutron-org/neutron)|`v1.0.4`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-neutron-v1.0.4`|[Example](./neutron)|

--- a/lumnetwork/README.md
+++ b/lumnetwork/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.6.2`|
+|Version|`v1.6.3`|
 |Binary|`lumd`|
 |Directory|`.lumd`|
 |ENV namespace|`LUMD`|
 |Repository|`https://github.com/lum-network/chain`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-lumnetwork-v1.6.2`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-lumnetwork-v1.6.3`|
 
 ## Examples
 

--- a/lumnetwork/build.yml
+++ b/lumnetwork/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: lum
         PROJECT_BIN: lumd
         PROJECT_DIR: .lumd
-        VERSION: v1.6.2
+        VERSION: v1.6.3
         REPOSITORY: https://github.com/lum-network/chain
         NAMESPACE: LUMD
         GOLANG_VERSION: 1.19.7-buster

--- a/lumnetwork/deploy.yml
+++ b/lumnetwork/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-lumnetwork-v1.6.2
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-lumnetwork-v1.6.3
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/chain.json

--- a/lumnetwork/docker-compose.yml
+++ b/lumnetwork/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-lumnetwork-v1.6.2
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-lumnetwork-v1.6.3
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Lum network will be upgraded to v1.6.3 at block 10444000.

https://dev.mintscan.io/lum/blocks/10444000
Estimated Target Date: Thu Nov 30 2023 16:41:32 GMT+0100 (GMT+01:00)

Proposal: https://dev.mintscan.io/lum/proposals/92