### PR TITLE
Upgrade Kyve to v1.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,7 @@ jobs:
           - project: kujira
             version: v0.9.1
           - project: kyve
-            version: v1.3.1
+            version: v1.4.0
           - project: likecoin
             version: v4.0.2
           - project: lumnetwork

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[kichain](https://github.com/KiFoundation/ki-tools)|`5.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kichain-5.0.1`|[Example](./kichain)|
 |[konstellation](https://github.com/konstellation/konstellation)|`v0.5.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-konstellation-v0.5.0`|[Example](./konstellation)|
 |[kujira](https://github.com/Team-Kujira/core)|`v0.9.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kujira-v0.9.1`|[Example](./kujira)|
-|[kyve](https://github.com/KYVENetwork/chain)|`v1.3.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kyve-v1.3.1`|[Example](./kyve)|
+|[kyve](https://github.com/KYVENetwork/chain)|`v1.4.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kyve-v1.4.0`|[Example](./kyve)|
 |[likecoin](https://github.com/likecoin/likecoin-chain)|`v4.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-likecoin-v4.0.2`|[Example](./likecoin)|
 |[lumnetwork](https://github.com/lum-network/chain)|`v1.6.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-lumnetwork-v1.6.2`|[Example](./lumnetwork)|
 |[mars](https://github.com/mars-protocol/hub.git)|`v1.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-mars-v1.0.2`|[Example](./mars)|

--- a/kyve/README.md
+++ b/kyve/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.3.1`|
+|Version|`v1.4.0`|
 |Binary|`kyved`|
 |Directory|`.kyve`|
 |ENV namespace|`KYVED`|
 |Repository|`https://github.com/KYVENetwork/chain`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kyve-v1.3.1`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kyve-v1.4.0`|
 
 ## Examples
 

--- a/kyve/build.yml
+++ b/kyve/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: kyve
         PROJECT_BIN: kyved
-        VERSION: v1.3.1
+        VERSION: v1.4.0
         REPOSITORY: https://github.com/KYVENetwork/chain
         NAMESPACE: KYVED
         PROJECT_DIR: .kyve

--- a/kyve/deploy.yml
+++ b/kyve/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kyve-v1.3.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kyve-v1.4.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/chain.json

--- a/kyve/docker-compose.yml
+++ b/kyve/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kyve-v1.3.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kyve-v1.4.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Kyve will be upgraded to v1.4.0 at block 3908000.

https://dev.mintscan.io/kyve/blocks/3908000
Estimated Target Date: Tue Dec 05 2023 13:28:39 GMT+0100 (GMT+01:00)

Proposal: https://dev.mintscan.io/kyve/proposals/21