### PR TITLE
Upgrade kava to v0.25.0 (kava 15 release)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
           - project: juno
             version: v17.1.1
           - project: kava
-            version: v0.24.0
+            version: v0.25.0
           - project: kichain
             version: 5.0.1
           - project: konstellation

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[irisnet](https://github.com/irisnet/irishub)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-irisnet-v2.0.1`|[Example](./irisnet)|
 |[jackal](https://github.com/JackalLabs/canine-chain)|`v3.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-jackal-v3.0.2`|[Example](./jackal)|
 |[juno](https://github.com/CosmosContracts/Juno)|`v17.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-juno-v17.1.1`|[Example](./juno)|
-|[kava](https://github.com/Kava-Labs/kava)|`v0.24.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kava-v0.24.0`|[Example](./kava)|
+|[kava](https://github.com/Kava-Labs/kava)|`v0.25.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kava-v0.25.0`|[Example](./kava)|
 |[kichain](https://github.com/KiFoundation/ki-tools)|`5.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kichain-5.0.1`|[Example](./kichain)|
 |[konstellation](https://github.com/konstellation/konstellation)|`v0.5.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-konstellation-v0.5.0`|[Example](./konstellation)|
 |[kujira](https://github.com/Team-Kujira/core)|`v0.9.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kujira-v0.9.1`|[Example](./kujira)|

--- a/kava/README.md
+++ b/kava/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v0.24.0`|
+|Version|`v0.25.0`|
 |Binary|`kava`|
 |Directory|`.kava`|
 |ENV namespace|`KAVA`|
 |Repository|`https://github.com/Kava-Labs/kava`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kava-v0.24.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kava-v0.25.0`|
 
 ## Examples
 

--- a/kava/build.yml
+++ b/kava/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: kava
         PROJECT_BIN: kava
-        VERSION: v0.24.0
+        VERSION: v0.25.0
         REPOSITORY: https://github.com/Kava-Labs/kava
         NAMESPACE: KAVA
         GOLANG_VERSION: 1.20-buster

--- a/kava/deploy.yml
+++ b/kava/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kava-v0.24.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kava-v0.25.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/chain.json

--- a/kava/docker-compose.yml
+++ b/kava/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kava-v0.24.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kava-v0.25.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
kava will be upgraded to v0.25.0 at block 7638000.

https://dev.mintscan.io/kava/blocks/7638000
Estimated Target Date: Thu Dec 07 2023 17:52:15 GMT+0100 (GMT+01:00)

Proposal: https://dev.mintscan.io/kava/proposals/168