### PR TITLE
Upgrade Umee to v6.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,7 +137,7 @@ jobs:
           # - project: terra
           #   version: v0.5.18
           - project: umee
-            version: v6.1.0
+            version: v6.2.0
           - project: ununifi
             version: v3.2.2
           - project: vidulum

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[starname](https://github.com/iov-one/starnamed)|`v0.11.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-starname-v0.11.5`|[Example](./starname)|
 |[stride](https://github.com/Stride-Labs/stride)|`v16.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-stride-v16.0.0`|[Example](./stride)|
 |[teritori](https://github.com/TERITORI/teritori-chain)|`v1.4.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-teritori-v1.4.0`|[Example](./teritori)|
-|[umee](https://github.com/umee-network/umee)|`v6.1.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-umee-v6.1.0`|[Example](./umee)|
+|[umee](https://github.com/umee-network/umee)|`v6.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-umee-v6.2.0`|[Example](./umee)|
 |[ununifi](https://github.com/UnUniFi/chain)|`v3.2.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-ununifi-v3.2.2`|[Example](./ununifi)|
 |[vidulum](https://github.com/vidulum/mainnet)|`v1.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-vidulum-v1.2.0`|[Example](./vidulum)|
 

--- a/umee/README.md
+++ b/umee/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v6.1.0`|
+|Version|`v6.2.0`|
 |Binary|`umeed`|
 |Directory|`.umee`|
 |ENV namespace|`umee`|
 |Repository|`https://github.com/crypto-org-chain/umee`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-umee-v6.1.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-umee-v6.2.0`|
 
 ## Examples
 

--- a/umee/build.yml
+++ b/umee/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: umee
         PROJECT_BIN: umeed
         PROJECT_DIR: .umee
-        VERSION: v6.1.0
+        VERSION: v6.2.0
         GOLANG_VERSION: 1.21-bullseye
         REPOSITORY: https://github.com/umee-network/umee
         NAMESPACE: UMEED

--- a/umee/deploy.yml
+++ b/umee/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-umee-v6.1.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-umee-v6.2.0
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/chain.json

--- a/umee/docker-compose.yml
+++ b/umee/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-umee-v6.1.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-umee-v6.2.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Umee will be upgraded to v6.2.0 at block 9561500.

https://dev.mintscan.io/umee/blocks/9561500
Estimated Target Date: Wed Dec 06 2023 16:28:41 GMT+0100 (GMT+01:00)

Proposal: https://dev.mintscan.io/umee/proposals/128