### PR TITLE
Upgrade Juno to v18.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
           - project: jackal
             version: v3.0.2
           - project: juno
-            version: v17.1.1
+            version: v18.0.0
           - project: kava
             version: v0.24.0
           - project: kichain

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.11.6-1688984159`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-injective-v1.11.6-1688984159`|[Example](./injective)|
 |[irisnet](https://github.com/irisnet/irishub)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-irisnet-v2.0.1`|[Example](./irisnet)|
 |[jackal](https://github.com/JackalLabs/canine-chain)|`v3.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-jackal-v3.0.2`|[Example](./jackal)|
-|[juno](https://github.com/CosmosContracts/Juno)|`v17.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-juno-v17.1.1`|[Example](./juno)|
+|[juno](https://github.com/CosmosContracts/Juno)|`v18.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-juno-v18.0.0`|[Example](./juno)|
 |[kava](https://github.com/Kava-Labs/kava)|`v0.24.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kava-v0.24.0`|[Example](./kava)|
 |[kichain](https://github.com/KiFoundation/ki-tools)|`5.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-kichain-5.0.1`|[Example](./kichain)|
 |[konstellation](https://github.com/konstellation/konstellation)|`v0.5.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-konstellation-v0.5.0`|[Example](./konstellation)|

--- a/juno/README.md
+++ b/juno/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v17.1.1`|
+|Version|`v18.0.0`|
 |Binary|`junod`|
 |Directory|`.juno`|
 |ENV namespace|`JUNOD`|
 |Repository|`https://github.com/CosmosContracts/Juno`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-juno-v17.1.1`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.2-juno-v18.0.0`|
 
 ## Examples
 

--- a/juno/build.yml
+++ b/juno/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: juno
         PROJECT_BIN: junod
         PROJECT_DIR: .juno
-        VERSION: v17.1.1
+        VERSION: v18.0.0
         REPOSITORY: https://github.com/CosmosContracts/juno
         NAMESPACE: JUNOD
         GOLANG_VERSION: 1.20-buster

--- a/juno/deploy.yml
+++ b/juno/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-juno-v17.1.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-juno-v18.0.0
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/chain.json

--- a/juno/docker-compose.yml
+++ b/juno/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-juno-v17.1.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.2-juno-v18.0.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Juno will be upgraded to v18.0.0 at block 12265007.

https://dev.mintscan.io/juno/blocks/12265007
Estimated Target Date: Mon Dec 11 2023 17:41:42 GMT+0100 (GMT+01:00)

Proposal: https://dev.mintscan.io/juno/proposals/325