### PR TITLE
Upgrade Evmos to v16.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
           - project: empowerchain
             version: v2.0.0
           - project: evmos
-            version: v15.0.0
+            version: v16.0.0
           - project: fetchhub
             version: v0.10.6
           - project: gitopia

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
           - project: empowerchain
             version: v2.0.0
           - project: evmos
-            version: v16.0.0
+            version: v16.0.1
           - project: fetchhub
             version: v0.10.6
           - project: gitopia

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[dydx](https://github.com/dydxprotocol/v4-chain)|`v2.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-dydx-v2.0.0`|[Example](./dydx)|
 |[emoney](https://github.com/e-money/em-ledger)|`v1.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-emoney-v1.2.0`|[Example](./emoney)|
 |[empowerchain](https://github.com/empowerchain/empowerchain)|`v2.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-empowerchain-v2.0.0`|[Example](./empowerchain)|
-|[evmos](https://github.com/evmos/evmos)|`v16.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.0`|[Example](./evmos)|
+|[evmos](https://github.com/evmos/evmos)|`v16.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.1`|[Example](./evmos)|
 |[fetchhub](https://github.com/fetchai/fetchd)|`v0.10.6`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-fetchhub-v0.10.6`|[Example](./fetchhub)|
 |[gitopia](https://github.com/gitopia/gitopia)|`v2.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-gitopia-v2.1.1`|[Example](./gitopia)|
 |[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.11.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-gravitybridge-v1.11.1`|[Example](./gravitybridge)|

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[dydx](https://github.com/dydxprotocol/v4-chain)|`v2.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-dydx-v2.0.0`|[Example](./dydx)|
 |[emoney](https://github.com/e-money/em-ledger)|`v1.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-emoney-v1.2.0`|[Example](./emoney)|
 |[empowerchain](https://github.com/empowerchain/empowerchain)|`v2.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-empowerchain-v2.0.0`|[Example](./empowerchain)|
-|[evmos](https://github.com/evmos/evmos)|`v15.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v15.0.0`|[Example](./evmos)|
+|[evmos](https://github.com/evmos/evmos)|`v16.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.0`|[Example](./evmos)|
 |[fetchhub](https://github.com/fetchai/fetchd)|`v0.10.6`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-fetchhub-v0.10.6`|[Example](./fetchhub)|
 |[gitopia](https://github.com/gitopia/gitopia)|`v2.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-gitopia-v2.1.1`|[Example](./gitopia)|
 |[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.11.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-gravitybridge-v1.11.1`|[Example](./gravitybridge)|

--- a/evmos/README.md
+++ b/evmos/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v15.0.0`|
+|Version|`v16.0.0`|
 |Binary|`evmosd`|
 |Directory|`.evmosd`|
 |ENV namespace|`EVMOSD`|
 |Repository|`https://github.com/evmos/evmos`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v15.0.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.0`|
 
 ## Examples
 

--- a/evmos/README.md
+++ b/evmos/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v16.0.0`|
+|Version|`v16.0.1`|
 |Binary|`evmosd`|
 |Directory|`.evmosd`|
 |ENV namespace|`EVMOSD`|
 |Repository|`https://github.com/evmos/evmos`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.1`|
 
 ## Examples
 

--- a/evmos/build.yml
+++ b/evmos/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: evmos
         PROJECT_BIN: evmosd
         PROJECT_DIR: .evmosd
-        VERSION: v15.0.0
+        VERSION: v16.0.0
         REPOSITORY: https://github.com/evmos/evmos
         NAMESPACE: EVMOSD
         GOLANG_VERSION: 1.20-buster

--- a/evmos/build.yml
+++ b/evmos/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: evmos
         PROJECT_BIN: evmosd
         PROJECT_DIR: .evmosd
-        VERSION: v16.0.0
+        VERSION: v16.0.1
         REPOSITORY: https://github.com/evmos/evmos
         NAMESPACE: EVMOSD
         GOLANG_VERSION: 1.20-buster

--- a/evmos/deploy.yml
+++ b/evmos/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.1
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/chain.json

--- a/evmos/deploy.yml
+++ b/evmos/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v15.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.0
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/chain.json

--- a/evmos/docker-compose.yml
+++ b/evmos/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.1
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/evmos/docker-compose.yml
+++ b/evmos/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v15.0.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-evmos-v16.0.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Evmos will be upgraded to v16.0.0 at block 18295000.

https://dev.mintscan.io/evmos/blocks/18295000
Estimated Target Date: Thu Jan 11 2024 23:26:56 GMT+0100 (Central European Standard Time)

Proposal: https://dev.mintscan.io/evmos/proposals/265