### PR TITLE
Upgrade Kujira to v0.9.3-1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
           - project: konstellation
             version: v0.5.0
           - project: kujira
-            version: v0.9.1
+            version: v0.9.3
           - project: kyve
             version: v1.4.0
           - project: likecoin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
           - project: konstellation
             version: v0.5.0
           - project: kujira
-            version: v0.9.3
+            version: v0.9.3-1
           - project: kyve
             version: v1.4.0
           - project: likecoin

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[kava](https://github.com/Kava-Labs/kava)|`v0.25.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kava-v0.25.0`|[Example](./kava)|
 |[kichain](https://github.com/KiFoundation/ki-tools)|`5.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kichain-5.0.1`|[Example](./kichain)|
 |[konstellation](https://github.com/konstellation/konstellation)|`v0.5.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-konstellation-v0.5.0`|[Example](./konstellation)|
-|[kujira](https://github.com/Team-Kujira/core)|`v0.9.3`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3`|[Example](./kujira)|
+|[kujira](https://github.com/Team-Kujira/core)|`v0.9.3-1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3-1`|[Example](./kujira)|
 |[kyve](https://github.com/KYVENetwork/chain)|`v1.4.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kyve-v1.4.0`|[Example](./kyve)|
 |[likecoin](https://github.com/likecoin/likecoin-chain)|`v4.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-likecoin-v4.1.1`|[Example](./likecoin)|
 |[lumnetwork](https://github.com/lum-network/chain)|`v1.6.3`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-lumnetwork-v1.6.3`|[Example](./lumnetwork)|

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[kava](https://github.com/Kava-Labs/kava)|`v0.25.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kava-v0.25.0`|[Example](./kava)|
 |[kichain](https://github.com/KiFoundation/ki-tools)|`5.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kichain-5.0.1`|[Example](./kichain)|
 |[konstellation](https://github.com/konstellation/konstellation)|`v0.5.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-konstellation-v0.5.0`|[Example](./konstellation)|
-|[kujira](https://github.com/Team-Kujira/core)|`v0.9.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.1`|[Example](./kujira)|
+|[kujira](https://github.com/Team-Kujira/core)|`v0.9.3`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3`|[Example](./kujira)|
 |[kyve](https://github.com/KYVENetwork/chain)|`v1.4.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kyve-v1.4.0`|[Example](./kyve)|
 |[likecoin](https://github.com/likecoin/likecoin-chain)|`v4.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-likecoin-v4.1.1`|[Example](./likecoin)|
 |[lumnetwork](https://github.com/lum-network/chain)|`v1.6.3`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-lumnetwork-v1.6.3`|[Example](./lumnetwork)|

--- a/kujira/README.md
+++ b/kujira/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v0.9.1`|
+|Version|`v0.9.3`|
 |Binary|`kujirad`|
 |Directory|`.kujira`|
 |ENV namespace|`KUJIRAD`|
 |Repository|`https://github.com/Team-Kujira/core`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.1`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3`|
 
 ## Examples
 

--- a/kujira/README.md
+++ b/kujira/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v0.9.3`|
+|Version|`v0.9.3-1`|
 |Binary|`kujirad`|
 |Directory|`.kujira`|
 |ENV namespace|`KUJIRAD`|
 |Repository|`https://github.com/Team-Kujira/core`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3-1`|
 
 ## Examples
 

--- a/kujira/build.yml
+++ b/kujira/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: kujira
         PROJECT_BIN: kujirad
         PROJECT_DIR: .kujira
-        VERSION: v0.9.1
+        VERSION: v0.9.3
         REPOSITORY: https://github.com/Team-Kujira/core
         NAMESPACE: KUJIRAD
         GOLANG_VERSION: 1.20-buster

--- a/kujira/build.yml
+++ b/kujira/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: kujira
         PROJECT_BIN: kujirad
         PROJECT_DIR: .kujira
-        VERSION: v0.9.3
+        VERSION: v0.9.3-1
         REPOSITORY: https://github.com/Team-Kujira/core
         NAMESPACE: KUJIRAD
         GOLANG_VERSION: 1.20-buster

--- a/kujira/deploy.yml
+++ b/kujira/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3-1
     env:
       - MONIKER=node_1
       # - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/chain.json

--- a/kujira/deploy.yml
+++ b/kujira/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3
     env:
       - MONIKER=node_1
       # - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/chain.json

--- a/kujira/docker-compose.yml
+++ b/kujira/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3-1
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/kujira/docker-compose.yml
+++ b/kujira/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-kujira-v0.9.3
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Kujira will be upgraded to v0.9.3 at block 16610000.

https://ping.pub/kujira/block/16610000
Estimated Time: 13/01/2024, 03:03:10

Proposal: https://ping.pub/kujira/gov/534