### PR TITLE
Upgrade injective to v1.12.0-1704530206

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
           - project: impacthub
             version: v0.18.1
           - project: injective
-            version: v1.11.6-1688984159
+            version: v1.12.0-1704530206
           - project: irisnet
             version: v2.0.1
           - project: jackal

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[gitopia](https://github.com/gitopia/gitopia)|`v2.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-gitopia-v2.1.1`|[Example](./gitopia)|
 |[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.11.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-gravitybridge-v1.11.1`|[Example](./gravitybridge)|
 |[impacthub](https://github.com/ixofoundation/ixo-blockchain)|`v0.18.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-impacthub-v0.18.1`|[Example](./impacthub)|
-|[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.11.6-1688984159`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-injective-v1.11.6-1688984159`|[Example](./injective)|
+|[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.12.0-1704530206`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-injective-v1.12.0-1704530206`|[Example](./injective)|
 |[irisnet](https://github.com/irisnet/irishub)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-irisnet-v2.0.1`|[Example](./irisnet)|
 |[jackal](https://github.com/JackalLabs/canine-chain)|`v3.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-jackal-v3.0.2`|[Example](./jackal)|
 |[juno](https://github.com/CosmosContracts/Juno)|`v18.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-juno-v18.0.0`|[Example](./juno)|

--- a/injective/README.md
+++ b/injective/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.11.6-1688984159`|
+|Version|`v1.12.0-1704530206`|
 |Binary|`injectived`|
 |Directory|`.injectived`|
 |ENV namespace|`INJECTIVED`|
 |Repository|`https://github.com/InjectiveLabs/injective-chain-releases`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-injective-v1.11.6-1688984159`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.4-injective-v1.12.0-1704530206`|
 
 ## Examples
 

--- a/injective/build.yml
+++ b/injective/build.yml
@@ -8,7 +8,7 @@ services:
         PROJECT: injective
         PROJECT_BIN: injectived
         PROJECT_DIR: .injectived
-        VERSION: v1.11.6-1688984159
+        VERSION: v1.12.0-1704530206
         BUILD_IMAGE: injective
     ports:
       - '26656:26656'

--- a/injective/deploy.yml
+++ b/injective/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-injective-v1.11.6-1688984159
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-injective-v1.12.0-1704530206
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/chain.json

--- a/injective/docker-compose.yml
+++ b/injective/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-injective-v1.11.6-1688984159
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.4-injective-v1.12.0-1704530206
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Injective will be upgraded to v1.12.0-1704530206 at block 57076000

https://www.mintscan.io/injective/block/57076000
Estimated Time: Jan 11th 2024, 12:12:44

Proposal: https://www.mintscan.io/injective/proposals/314