### PR TITLE
Upgrade fetch to v0.11.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
           - project: evmos
             version: v16.0.1
           - project: fetchhub
-            version: v0.10.6
+            version: v0.11.3
           - project: gitopia
             version: v2.1.1
           - project: gravitybridge

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[emoney](https://github.com/e-money/em-ledger)|`v1.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-emoney-v1.2.0`|[Example](./emoney)|
 |[empowerchain](https://github.com/empowerchain/empowerchain)|`v2.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-empowerchain-v2.0.0`|[Example](./empowerchain)|
 |[evmos](https://github.com/evmos/evmos)|`v16.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-evmos-v16.0.1`|[Example](./evmos)|
-|[fetchhub](https://github.com/fetchai/fetchd)|`v0.10.6`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-fetchhub-v0.10.6`|[Example](./fetchhub)|
+|[fetchhub](https://github.com/fetchai/fetchd)|`v0.11.3`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-fetchhub-v0.11.3`|[Example](./fetchhub)|
 |[gitopia](https://github.com/gitopia/gitopia)|`v2.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-gitopia-v2.1.1`|[Example](./gitopia)|
 |[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.11.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-gravitybridge-v1.11.1`|[Example](./gravitybridge)|
 |[impacthub](https://github.com/ixofoundation/ixo-blockchain)|`v0.18.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-impacthub-v0.18.1`|[Example](./impacthub)|

--- a/fetchhub/README.md
+++ b/fetchhub/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v0.10.6`|
+|Version|`v0.11.3`|
 |Binary|`fetchd`|
 |Directory|`.fetchd`|
 |ENV namespace|`FETCH`|
 |Repository|`https://github.com/fetchai/fetchd`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-fetchhub-v0.10.6`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-fetchhub-v0.11.3`|
 
 ## Examples
 

--- a/fetchhub/deploy.yml
+++ b/fetchhub/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.5-fetchhub-v0.10.6
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.5-fetchhub-v0.11.3
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/chain.json

--- a/fetchhub/docker-compose.yml
+++ b/fetchhub/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.5-fetchhub-v0.10.6
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.5-fetchhub-v0.11.3
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Fetch will be upgraded to v0.11.3 at block 14699873.

https://dev.mintscan.io/fetchai/blocks/14699873

Proposal: https://dev.mintscan.io/fetchai/proposals/25