### PR TITLE
Upgrade persistence v10.3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,7 +115,7 @@ jobs:
           - project: passage
             version: v2.3.0
           - project: persistence
-            version: v10.2.0
+            version: v10.3.0
           - project: regen
             version: v5.1.1
           - project: rizon

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[osmosis](https://github.com/osmosis-labs/osmosis)|`v21.2.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-osmosis-v21.2.1`|[Example](./osmosis)|
 |[panacea](https://github.com/medibloc/panacea-core)|`v2.0.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-panacea-v2.0.5`|[Example](./panacea)|
 |[passage](https://github.com/envadiv/Passage3D)|`v2.3.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-passage-v2.3.0`|[Example](./passage)|
-|[persistence](https://github.com/persistenceOne/persistenceCore)|`v10.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-persistence-v10.2.0`|[Example](./persistence)|
+|[persistence](https://github.com/persistenceOne/persistenceCore)|`v10.3.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-persistence-v10.3.0`|[Example](./persistence)|
 |[regen](https://github.com/regen-network/regen-ledger)|`v5.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-regen-v5.1.1`|[Example](./regen)|
 |[rizon](https://github.com/rizon-world/rizon)|`v0.4.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-rizon-v0.4.1`|[Example](./rizon)|
 |[seinetwork](https://github.com/sei-protocol/sei-chain)|`1.2.2beta-postfix`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-seinetwork-1.2.2beta-postfix`|[Example](./seinetwork)|

--- a/persistence/README.md
+++ b/persistence/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v10.2.0`|
+|Version|`v10.3.0`|
 |Binary|`persistenceCore`|
 |Directory|`.persistenceCore`|
 |ENV namespace|`PERSISTENCECORE`|
 |Repository|`https://github.com/persistenceOne/persistenceCore`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-persistence-v10.2.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.5-persistence-v10.3.0`|
 
 ## Examples
 

--- a/persistence/build.yml
+++ b/persistence/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: persistence
         PROJECT_BIN: persistenceCore
-        VERSION: v10.2.0
+        VERSION: v10.3.0
         REPOSITORY: https://github.com/persistenceOne/persistenceCore
         NAMESPACE: PERSISTENCECORE
         GOLANG_VERSION: 1.21-bullseye

--- a/persistence/deploy.yml
+++ b/persistence/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.5-persistence-v10.2.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.5-persistence-v10.3.0
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/chain.json

--- a/persistence/docker-compose.yml
+++ b/persistence/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.5-persistence-v10.2.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.5-persistence-v10.3.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Persistence will be upgraded to v10.3.0 at block 14965000.

https://dev.mintscan.io/persistence/blocks/14965000

Proposal: https://dev.mintscan.io/persistence/proposals/67