### PR TITLE
Add & update terra to v2.11.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,8 +144,8 @@ jobs:
             version: v0.11.5
           - project: teritori
             version: v2.0.6
-          # - project: terra
-          #   version: v0.5.18
+          - project: terra
+            version: v2.11.1
           - project: umee
             version: v6.3.0
           - project: ununifi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: set-matrix
-        run: echo "matrix=$(find * -type f -name build.yml -not -path "terra*" | xargs dirname | sort | uniq | jq --raw-input . | jq -c --slurp .)" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(find * -type f -name build.yml | xargs dirname | sort | uniq | jq --raw-input . | jq -c --slurp .)" >> $GITHUB_OUTPUT
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[starname](https://github.com/iov-one/starnamed)|`v0.11.5`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.14-starname-v0.11.5`|[Example](./starname)|
 |[stride](https://github.com/Stride-Labs/stride)|`v22.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.14-stride-v22.0.0`|[Example](./stride)|
 |[teritori](https://github.com/TERITORI/teritori-chain)|`v2.0.6`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.14-teritori-v2.0.6`|[Example](./teritori)|
+|[terra](https://github.com/terra-money/core)|`v2.11.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.14-terra-v2.11.1`|[Example](./terra)|
 |[umee](https://github.com/umee-network/umee)|`v6.3.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.14-umee-v6.3.0`|[Example](./umee)|
 |[ununifi](https://github.com/UnUniFi/chain)|`v4.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.14-ununifi-v4.0.1`|[Example](./ununifi)|
 |[vidulum](https://github.com/vidulum/mainnet)|`v1.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.14-vidulum-v1.2.0`|[Example](./vidulum)|

--- a/terra/README.md
+++ b/terra/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v0.5.18`|
+|Version|`v2.11.1`|
 |Binary|`terrad`|
 |Directory|`.terra`|
 |ENV namespace|`TERRAD`|
 |Repository|`https://github.com/terra-money/core`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.14-terra-v0.5.18`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.14-terra-v2.11.1`|
 
 ## Examples
 

--- a/terra/build.yml
+++ b/terra/build.yml
@@ -7,10 +7,11 @@ services:
       args:
         PROJECT: terra
         PROJECT_BIN: terrad
-        VERSION: v0.5.18
+        VERSION: v2.11.1
         REPOSITORY: https://github.com/terra-money/core.git
         NAMESPACE: TERRAD
         PROJECT_DIR: .terra
+        GOLANG_VERSION: 1.20-buster
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/terra/deploy.yml
+++ b/terra/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.14-terra-v0.5.18
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.14-terra-v2.11.1
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/chain.json

--- a/terra/docker-compose.yml
+++ b/terra/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.14-terra-v0.5.18
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.14-terra-v2.11.1
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Terra was previously removed from the build & readme. https://github.com/akash-network/cosmos-omnibus/pull/192
I don't see a reason to not add it again now that the build is stable again.