### PR TITLE
Upgrade cosmoshub to v16.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
           - project: comdex
             version: v13.4.0
           - project: cosmoshub
-            version: v15.2.0
+            version: v16.0.0
           - project: crescent
             version: v4.2.0
           - project: cronos

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[cheqd](https://github.com/cheqd/cheqd-node)|`0.6.9`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cheqd-0.6.9`|[Example](./cheqd)|
 |[chihuahua](https://github.com/ChihuahuaChain/chihuahua)|`v6.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.15-chihuahua-v6.0.1`|[Example](./chihuahua)|
 |[comdex](https://github.com/comdex-official/comdex)|`v13.4.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.15-comdex-v13.4.0`|[Example](./comdex)|
-|[cosmoshub](https://github.com/cosmos/gaia)|`v15.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cosmoshub-v15.2.0`|[Example](./cosmoshub)|
+|[cosmoshub](https://github.com/cosmos/gaia)|`v16.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cosmoshub-v16.0.0`|[Example](./cosmoshub)|
 |[crescent](https://github.com/crescent-network/crescent)|`v4.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.15-crescent-v4.2.0`|[Example](./crescent)|
 |[cronos](https://github.com/crypto-org-chain/cronos)|`v1.0.9`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cronos-v1.0.9`|[Example](./cronos)|
 |[cryptoorgchain](https://github.com/crypto-org-chain/chain-main)|`v4.2.9`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cryptoorgchain-v4.2.9`|[Example](./cryptoorgchain)|

--- a/cosmoshub/README.md
+++ b/cosmoshub/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v15.2.0`|
+|Version|`v16.0.0`|
 |Binary|`gaiad`|
 |Directory|`.gaia`|
 |ENV namespace|`GAIAD`|
 |Repository|`https://github.com/cosmos/gaia`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cosmoshub-v15.2.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cosmoshub-v16.0.0`|
 
 ## Examples
 

--- a/cosmoshub/build.yml
+++ b/cosmoshub/build.yml
@@ -12,6 +12,7 @@ services:
         REPOSITORY: https://github.com/cosmos/gaia
         NAMESPACE: GAIAD
         GOLANG_VERSION: 1.21-bullseye
+        DEBIAN_VERSION: bullseye
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/cosmoshub/build.yml
+++ b/cosmoshub/build.yml
@@ -8,10 +8,10 @@ services:
         PROJECT: cosmoshub
         PROJECT_BIN: gaiad
         PROJECT_DIR: .gaia
-        VERSION: v15.2.0
+        VERSION: v16.0.0
         REPOSITORY: https://github.com/cosmos/gaia
         NAMESPACE: GAIAD
-        GOLANG_VERSION: 1.20-buster
+        GOLANG_VERSION: 1.21-bullseye
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/cosmoshub/deploy.yml
+++ b/cosmoshub/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cosmoshub-v15.2.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cosmoshub-v16.0.0
     env:
       - MONIKER=node_1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/chain.json

--- a/cosmoshub/docker-compose.yml
+++ b/cosmoshub/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cosmoshub-v15.2.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.15-cosmoshub-v16.0.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Upgrade cosmoshub to v16.0.0.

The chain will be upgraded at block 20440500.
https://www.mintscan.io/cosmos/block/20440500

Estimated Time (UTC): May 15th 2024, 16:23:06+00:00