### PR TITLE
Update Chihuahua to v7.0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           - project: cheqd
             version: 0.6.9
           - project: chihuahua
-            version: v7.0.1
+            version: v7.0.2
           - project: comdex
             version: v13.4.0
           - project: cosmoshub

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           - project: cheqd
             version: 0.6.9
           - project: chihuahua
-            version: v7
+            version: v7.0.1
           - project: comdex
             version: v13.4.0
           - project: cosmoshub

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[bostrom](https://github.com/cybercongress/go-cyber)|`v0.3.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-bostrom-v0.3.2`|[Example](./bostrom)|
 |[canto](https://github.com/Canto-Network/Canto)|`v7.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-canto-v7.0.0`|[Example](./canto)|
 |[cheqd](https://github.com/cheqd/cheqd-node)|`0.6.9`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-cheqd-0.6.9`|[Example](./cheqd)|
-|[chihuahua](https://github.com/ChihuahuaChain/chihuahua)|`v7`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7`|[Example](./chihuahua)|
+|[chihuahua](https://github.com/ChihuahuaChain/chihuahua)|`v7.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.1`|[Example](./chihuahua)|
 |[comdex](https://github.com/comdex-official/comdex)|`v13.4.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-comdex-v13.4.0`|[Example](./comdex)|
 |[cosmoshub](https://github.com/cosmos/gaia)|`v17.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-cosmoshub-v17.2.0`|[Example](./cosmoshub)|
 |[crescent](https://github.com/crescent-network/crescent)|`v4.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-crescent-v4.2.0`|[Example](./crescent)|

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[bostrom](https://github.com/cybercongress/go-cyber)|`v0.3.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-bostrom-v0.3.2`|[Example](./bostrom)|
 |[canto](https://github.com/Canto-Network/Canto)|`v7.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-canto-v7.0.0`|[Example](./canto)|
 |[cheqd](https://github.com/cheqd/cheqd-node)|`0.6.9`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-cheqd-0.6.9`|[Example](./cheqd)|
-|[chihuahua](https://github.com/ChihuahuaChain/chihuahua)|`v7.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.1`|[Example](./chihuahua)|
+|[chihuahua](https://github.com/ChihuahuaChain/chihuahua)|`v7.0.2`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.2`|[Example](./chihuahua)|
 |[comdex](https://github.com/comdex-official/comdex)|`v13.4.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-comdex-v13.4.0`|[Example](./comdex)|
 |[cosmoshub](https://github.com/cosmos/gaia)|`v17.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-cosmoshub-v17.2.0`|[Example](./cosmoshub)|
 |[crescent](https://github.com/crescent-network/crescent)|`v4.2.0`|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-crescent-v4.2.0`|[Example](./crescent)|

--- a/chihuahua/README.md
+++ b/chihuahua/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v7`|
+|Version|`v7.0.1`|
 |Binary|`chihuahuad`|
 |Directory|`.chihuahuad`|
 |ENV namespace|`CHIHUAHUAD`|
 |Repository|`https://github.com/ChihuahuaChain/chihuahua`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.1`|
 
 ## Examples
 

--- a/chihuahua/README.md
+++ b/chihuahua/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v7.0.1`|
+|Version|`v7.0.2`|
 |Binary|`chihuahuad`|
 |Directory|`.chihuahuad`|
 |ENV namespace|`CHIHUAHUAD`|
 |Repository|`https://github.com/ChihuahuaChain/chihuahua`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.1`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.2`|
 
 ## Examples
 

--- a/chihuahua/build.yml
+++ b/chihuahua/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: chihuahua
         PROJECT_BIN: chihuahuad
-        VERSION: v7
+        VERSION: v7.0.1
         REPOSITORY: https://github.com/ChihuahuaChain/chihuahua
         NAMESPACE: CHIHUAHUAD
         PROJECT_DIR: .chihuahuad

--- a/chihuahua/build.yml
+++ b/chihuahua/build.yml
@@ -7,7 +7,7 @@ services:
       args:
         PROJECT: chihuahua
         PROJECT_BIN: chihuahuad
-        VERSION: v7.0.1
+        VERSION: v7.0.2
         REPOSITORY: https://github.com/ChihuahuaChain/chihuahua
         NAMESPACE: CHIHUAHUAD
         PROJECT_DIR: .chihuahuad

--- a/chihuahua/deploy.yml
+++ b/chihuahua/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.2
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/chain.json

--- a/chihuahua/deploy.yml
+++ b/chihuahua/deploy.yml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.1
     env:
       - MONIKER=my-moniker-1
       - CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/chain.json

--- a/chihuahua/docker-compose.yml
+++ b/chihuahua/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.1
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/chihuahua/docker-compose.yml
+++ b/chihuahua/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   node_1:
-    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v0.4.18-chihuahua-v7.0.2
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
Chihuahua will upgraded to v7.0.1 at https://www.mintscan.io/chihuahua/block/13250000

Jun 17th 2024, 14:11:31+00:00.

Proposal: https://www.mintscan.io/chihuahua/proposals/77