### PR TITLE
Build images for multiple architectures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -172,7 +172,10 @@ jobs:
         run: |
           touch .env # Create dummy env file
           cd ${{matrix.project}}
-          docker buildx bake -f build.yml --set node_1.tags=ghcr.io/${{ github.repository }}:${GITHUB_REF#refs/tags/}-${{matrix.project}}-${{matrix.version}}${{matrix.tag_suffix}} --push
+          docker buildx bake -f build.yml \
+            --set node_1.platform=linux/arm/v7,linux/arm64/v8,linux/amd64 \
+            --set node_1.tags=ghcr.io/${{ github.repository }}:${GITHUB_REF#refs/tags/}-${{matrix.project}}-${{matrix.version}} \
+            --push
   build_generic:
     runs-on: ubuntu-latest
     strategy:
@@ -194,4 +197,7 @@ jobs:
         run: |
           touch .env # Create dummy env file
           cd generic
-          docker buildx bake -f build.yml --set node_1.tags=ghcr.io/${{ github.repository }}:${GITHUB_REF#refs/tags/}-generic --push
+          docker buildx bake -f build.yml \
+            --set node_1.platform=linux/arm/v7,linux/arm64/v8,linux/amd64 \
+            --set node_1.tags=ghcr.io/${{ github.repository }}:${GITHUB_REF#refs/tags/}-generic \
+            --push


### PR DESCRIPTION
Initial test of multi-arch builds. As described in #898 - we would need to take this further to speed up builds, and solve the chains that use pre-built amd64 binaries.