### PR TITLE
Rename remote binary when BINARY_ZIP_PATH is set

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -39,7 +39,7 @@ if [[ -n "$BINARY_URL" && ! -f "/bin/$PROJECT_BIN" ]]; then
     *"tar archive"*)            mv /bin/$PROJECT_BIN /bin/$PROJECT_BIN.tar && tar -xf /bin/$PROJECT_BIN.tar -C /bin && rm /bin/$PROJECT_BIN.tar;;
     *"zip archive data"*)       mv /bin/$PROJECT_BIN /bin/$PROJECT_BIN.zip && unzip /bin/$PROJECT_BIN.zip -d /bin && rm /bin/$PROJECT_BIN.zip;;
   esac
-  [ -n "$BINARY_ZIP_PATH" ] && mv /bin/${BINARY_ZIP_PATH} /bin
+  [ -n "$BINARY_ZIP_PATH" ] && mv /bin/${BINARY_ZIP_PATH} /bin/$PROJECT_BIN
   chmod +x /bin/$PROJECT_BIN
 
   if [ -n "$WASMVM_URL" ]; then


### PR DESCRIPTION
Handles cases where the zip file contains a non-standard binary filename (e.g. version suffix `akash-v1.0.0`). In this case the `BINARY_ZIP_PATH` can be set to e.g. `build/akash-v1.0.0` and the binary will be renamed to `/bin/akash` instead of `/bin/akash-v1.0.0` as it was previously. 