### PR TITLE
Skip tests when entrypoint.sh changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
           target-file: build.yml
           common-dependency-paths: |-
             Dockerfile
-            entrypoint.sh
     outputs:
       projects: ${{ steps.list_changed_directories.outputs.changed-directories }}
 


### PR DESCRIPTION
`entrypoint.sh` makes no difference to the outcome of the `test.yml` action so we should not treat this as a common dependency for the action