### PR TITLE
Update Jackal to v4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[impacthub](https://github.com/ixofoundation/ixo-blockchain)|`v0.18.1`|`ghcr.io/akash-network/cosmos-omnibus:v1.1.2-impacthub-v0.18.1`|[Example](./impacthub)|
 |[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.13.3`|`ghcr.io/akash-network/cosmos-omnibus:v1.1.2-injective-v1.13.3`|[Example](./injective)|
 |[irisnet](https://github.com/irisnet/irishub)|`v2.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v1.1.2-irisnet-v2.0.1`|[Example](./irisnet)|
-|[jackal](https://github.com/JackalLabs/canine-chain)|`v4.3.0`|`ghcr.io/akash-network/cosmos-omnibus:v1.1.2-jackal-v4.3.0`|[Example](./jackal)|
+|[jackal](https://github.com/JackalLabs/canine-chain)|`v4.4.0`|`ghcr.io/akash-network/cosmos-omnibus:v1.1.2-jackal-v4.4.0`|[Example](./jackal)|
 |[juno](https://github.com/CosmosContracts/Juno)|`v26.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v1.1.2-juno-v26.0.0`|[Example](./juno)|
 |[kava](https://github.com/Kava-Labs/kava)|`v0.25.0`|`ghcr.io/akash-network/cosmos-omnibus:v1.1.2-kava-v0.25.0`|[Example](./kava)|
 |[kichain](https://github.com/KiFoundation/ki-tools)|`5.0.1`|`ghcr.io/akash-network/cosmos-omnibus:v1.1.2-kichain-5.0.1`|[Example](./kichain)|

--- a/jackal/README.md
+++ b/jackal/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v4.3.0`|
+|Version|`v4.4.0`|
 |Binary|`canined`|
 |Directory|`.canine`|
 |ENV namespace|`CANINED`|
 |Repository|`https://github.com/JackalLabs/canine-chain`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v1.1.2-jackal-v4.3.0`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v1.1.2-jackal-v4.4.0`|
 
 ## Examples
 

--- a/jackal/build.yml
+++ b/jackal/build.yml
@@ -5,7 +5,7 @@ services:
       args:
         PROJECT: jackal
         PROJECT_BIN: canined
-        VERSION: v4.3.0
+        VERSION: v4.4.0
         REPOSITORY: https://github.com/JackalLabs/canine-chain
         PROJECT_DIR: .canine
         GOLANG_VERSION: 1.22

--- a/jackal/build.yml
+++ b/jackal/build.yml
@@ -10,6 +10,7 @@ services:
         PROJECT_DIR: .canine
         GOLANG_VERSION: 1.22
         DEBIAN_VERSION: bullseye
+        BUILD_CMD: make install VERSION=4.4.0
     ports:
       - '26656:26656'
       - '26657:26657'

--- a/jackal/deploy.yml
+++ b/jackal/deploy.yml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v1.1.2-jackal-v4.3.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v1.1.2-jackal-v4.4.0
     env:
       - MONIKER=Cosmos Omnibus Node
       - P2P_POLKACHU=1

--- a/jackal/docker-compose.yml
+++ b/jackal/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v1.1.2-jackal-v4.3.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v1.1.2-jackal-v4.4.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
The `VERSION=4.4.0` argument is required in the`BUILD_CMD` as there are currently multiple tags pointing to the commit and `canined version` returns `canary` without it. Ideally this would be removed in future versions if `version` output is correct.

This happens because `git describe --tags` [used here](https://github.com/JackalLabs/canine-chain/blob/v4.4.0/Makefile#L4) finds the most recent tag that is reachable from a commit, and there are 3 tags pointing to this commit including `canary` and all were created at the same time. Other validators were reporting that the version output was correct for them, so I suspect the git version matters and in later versions it uses alphabetical sorting if all tags have the same time. 

This could be solved upstream by ~~using `git describe --tags  --match "v*"` or just~~ ensuring the `canary` tag is created prior to the official release tag, which I expect it usually would be.