### PR TITLE
feat: add Google Cloud Storage support for key and snapshot backup/restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,15 @@ RUN curl -L https://github.com/storj/storj/releases/latest/download/uplink_linux
     install uplink /usr/bin/uplink && \
     rm -f uplink uplink_linux_amd64.zip
 
+# Install Google Cloud SDK (for gsutil/gcloud)
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
+      | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update && \
+    apt-get install --no-install-recommends --assume-yes google-cloud-sdk && \
+    apt-get clean
+
 # Copy scripts
 COPY entrypoint.sh snapshot.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh /usr/bin/snapshot.sh

--- a/_examples/snapshot_backup/GCS_SETUP.md
+++ b/_examples/snapshot_backup/GCS_SETUP.md
@@ -1,0 +1,120 @@
+# 📦 Setting Up Google Cloud Storage for Snapshot Backups
+
+This guide walks you through creating a Google Cloud Storage (GCS) bucket, configuring a service account, and generating a key file for automated snapshot backups using the [cosmos-omnibus](https://github.com/ovrclk/cosmos-omnibus) container.
+
+---
+
+## ⚙️ Prerequisites
+
+Install the Google Cloud SDK:
+
+```
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list
+apt update && apt install -y google-cloud-cli
+```
+
+---
+
+## 🪣 1. Create a GCS Bucket
+
+```
+export GCS_PROJECT_ID="your-project-id"
+export GCS_BUCKET="your-snapshot-bucket"
+
+gcloud config set project "$GCS_PROJECT_ID"
+gcloud storage buckets create gs://$GCS_BUCKET --location=us-central1
+```
+
+---
+
+## 📆 2. (Optional) Set Lifecycle Rules
+
+To auto-delete old snapshots (e.g. after 60 days):
+
+```
+cat > lifecycle.json <<EOF
+{
+  "rule": [
+    {
+      "action": {"type": "Delete"},
+      "condition": {"age": 60}
+    }
+  ]
+}
+EOF
+
+gsutil lifecycle set lifecycle.json gs://$GCS_BUCKET
+```
+
+---
+
+## 👤 3. Create a Service Account
+
+```
+gcloud iam service-accounts create my-akash-rpc-bkp-svc \
+  --description="Backup service account for GCS uploads" \
+  --display-name="RPC Backup Service"
+```
+
+---
+
+## 🔐 4. Grant Permissions
+
+To allow uploading and updating files (like `snapshot.json`), grant `objectAdmin`:
+
+```
+gsutil iam ch \
+  serviceAccount:my-akash-rpc-bkp-svc@${GCS_PROJECT_ID}.iam.gserviceaccount.com:objectAdmin \
+  gs://$GCS_BUCKET
+```
+
+---
+
+## 🗝 5. Generate and Download the Service Account Key
+
+```
+gcloud iam service-accounts keys create gcs-backup-key.json \
+  --iam-account=my-akash-rpc-bkp-svc@${GCS_PROJECT_ID}.iam.gserviceaccount.com
+```
+
+This creates a `gcs-backup-key.json` file that you'll mount into the container.
+
+---
+
+## 🧪 6. Example Docker Compose Setup
+
+> When testing **key backup/restore**, make sure `KEY_PATH` starts with `gs://`:
+>
+> ```
+> - KEY_PATH=gs://your-bucket/key-backups
+> ```
+
+### Example service config:
+
+```
+  node:
+    image: ghcr.io/akash-network/cosmos-omnibus:v1.2.12-akash-v0.38.1
+    restart: no
+    environment:
+      - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/main/mainnet/meta.json
+      # GCS Backup Configuration
+      - GCS_ENABLED=1
+      - GCS_BUCKET_PATH=gs://your-bucket/akash/snapshots
+      - GCS_KEY_FILE=/root/gcs-backup-key.json
+      - SNAPSHOT_KEEP_LAST=2  # always keep at least 2 snapshots
+      #- SNAPSHOT_ON_START=1   # optional: trigger immediate snapshot on container start
+      # For snapshot restore
+      #- SNAPSHOT_JSON=https://storage.googleapis.com/your-bucket/akash/snapshots/snapshot.json
+      # Key backup/restore path
+      - KEY_PATH=gs://your-bucket/akash/node1-key-backups
+    volumes:
+      - /root/akash-node:/root/.akash
+      - /root/gcs-backup-key.json:/root/gcs-backup-key.json:ro
+```
+
+---
+
+## ✅ Done!
+
+Your container can now automatically upload snapshots and `snapshot.json` metadata to GCS — and also restore from GCS using the same service account.

--- a/_examples/snapshot_backup/README.md
+++ b/_examples/snapshot_backup/README.md
@@ -3,3 +3,5 @@
 The snapshot script will shutdown the node for as long as the archive and upload process takes, 
 so use a dedicated node for creating snapshots. [See the README](/README.md#snapshot-restore) for the configuration options available.
 
+💡 Want to use Google Cloud Storage (GCS) for backups? [See GCS_SETUP.md](./GCS_SETUP.md)
+

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -11,6 +11,7 @@ SNAPSHOT_CMD="${SNAPSHOT_CMD:-$@}"
 SNAPSHOT_PATH="${SNAPSHOT_PATH%/}"
 SNAPSHOT_PREFIX="${SNAPSHOT_PREFIX:-$CHAIN_ID}"
 SNAPSHOT_RETAIN="${SNAPSHOT_RETAIN:-2 days}"
+SNAPSHOT_KEEP_LAST="${SNAPSHOT_KEEP_LAST:-2}"
 SNAPSHOT_METADATA="${SNAPSHOT_METADATA:-1}"
 SNAPSHOT_SAVE_FORMAT="${SNAPSHOT_SAVE_FORMAT:-$SNAPSHOT_FORMAT}"
 valid_snapshot_formats=(tar tar.gz tar.zst)
@@ -35,6 +36,37 @@ if [ -n "$ZSTD_LONG" ]; then
   zstd_extra_arg="--long=$ZSTD_LONG"
 fi
 
+# Validate SNAPSHOT_KEEP_LAST if set
+if [[ -n "$SNAPSHOT_KEEP_LAST" && ! "$SNAPSHOT_KEEP_LAST" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: Invalid SNAPSHOT_KEEP_LAST value '$SNAPSHOT_KEEP_LAST'. Must be a non-negative integer."
+  exit 1
+fi
+
+GCS_BUCKET_AND_PATH="${GCS_BUCKET_PATH#gs://}"
+GCS_BUCKET="${GCS_BUCKET_AND_PATH%%/*}"
+GCS_PATH="${GCS_BUCKET_AND_PATH#*/}"
+GCS_PUBLIC_BASE_URL="https://storage.googleapis.com/${GCS_BUCKET_AND_PATH}"
+
+is_gcs_object_public() {
+  local object_path="$1"
+  gsutil acl get "$object_path" 2>/dev/null | jq -e '.[] | select(.entity == "allUsers" and .role == "READER")' >/dev/null
+}
+
+make_gcs_file_public() {
+  local file="$1"
+  local object_uri="gs://${GCS_BUCKET_AND_PATH}/${file}"
+  if [[ "$file" == gs://* ]]; then
+    echo "ERROR: make_gcs_file_public was passed a full URI, expected filename only: '$file'" >&2
+    return 1
+  fi
+  if ! is_gcs_object_public "$object_uri"; then
+    echo "$TIME: Making ${object_uri} publicly accessible at ${GCS_PUBLIC_BASE_URL}/${file}"
+    gsutil acl ch -u AllUsers:R "$object_uri"
+  else
+    echo "$TIME: $object_uri is already public, skipping acl ch"
+  fi
+}
+
 TIME=$(date -u +%T)
 DOW=$(date +%u)
 
@@ -46,7 +78,10 @@ PID=$!
 while true; do
     TIME=$(date -u +%T)
     DOW=$(date +%u)
-    if [[ ($SNAPSHOT_DAY == "*") || ($SNAPSHOT_DAY == $DOW) ]] && [[ $SNAPSHOT_TIME == $TIME ]]; then
+    if ( [[ "$SNAPSHOT_DAY" == "*" ]] || [[ "$SNAPSHOT_DAY" == "$DOW" ]] ) && [[ "$SNAPSHOT_TIME" == "$TIME" ]] || [[ "$SNAPSHOT_ON_START" == "1" ]]; then
+        # to avoid repeated snapshot triggers every loop
+        SNAPSHOT_ON_START=0
+
         echo "$TIME: Stopping server"
         kill -15 $PID
         wait
@@ -67,31 +102,57 @@ while true; do
 
         if [ -n "$STORJ_ACCESS_GRANT" ]; then
           case "${SNAPSHOT_SAVE_FORMAT,,}" in
-            tar.gz)   (tar c -C $SNAPSHOT_DIR . | gzip -1 | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | uplink cp $storj_args - "$storj_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
+            tar.gz)   (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | gzip -1 | uplink cp $storj_args - "$storj_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
             # Compress level can be set via `ZSTD_CLEVEL`, default `3`
             # No. of threads can be set via `ZSTD_NBTHREADS`, default `1`, `0` = detected no. of cpu cores
-            tar.zst)  (tar c -C $SNAPSHOT_DIR . | zstd -c $zstd_extra_arg | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | uplink cp $storj_args - "$storj_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
+            tar.zst)  (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | zstd -c $zstd_extra_arg | uplink cp $storj_args - "$storj_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
             # Catchall, assume to be tar
             *)        (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | uplink cp $storj_args - "$storj_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
           esac
-        else
+	elif [ "$GCS_ENABLED" == "1" ]; then
+          # GCS
+          gcs_uri="${GCS_BUCKET_PATH}/${SNAPSHOT_PREFIX}_${timestamp}.${SNAPSHOT_SAVE_FORMAT}"
           case "${SNAPSHOT_SAVE_FORMAT,,}" in
-            tar.gz)   (tar c -C $SNAPSHOT_DIR . | gzip -1 | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | s3cmd $aws_args put - "$s3_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
+            tar.gz)   (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | gzip -1 | gsutil -q cp - "$gcs_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
+            tar.zst)  (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | zstd -c $zstd_extra_arg | gsutil -q cp - "$gcs_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
+            *)        (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | gsutil -q cp - "$gcs_uri") 2>&1 | stdbuf -o0 tr '\r' '\n' ;;
+          esac
+          make_gcs_file_public "$(basename "$gcs_uri")"
+        else
+          # AWS S3
+          case "${SNAPSHOT_SAVE_FORMAT,,}" in
+            tar.gz)   (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | gzip -1 | s3cmd $aws_args put - "$s3_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
             # Compress level can be set via `ZSTD_CLEVEL`, default `3`
             # No. of threads can be set via `ZSTD_NBTHREADS`, default `1`, `0` = detected no. of cpu cores
-            tar.zst)  (tar c -C $SNAPSHOT_DIR . | zstd -c $zstd_extra_arg | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | s3cmd $aws_args put - "$s3_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
+            tar.zst)  (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | zstd -c $zstd_extra_arg | s3cmd $aws_args put - "$s3_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
             # Catchall, assume to be tar
             *)        (tar c -C $SNAPSHOT_DIR . | pv -petrafb -i 5 -s $SNAPSHOT_SIZE | s3cmd $aws_args put - "$s3_uri") 2>&1 | stdbuf -o0 tr '\r' '\n';;
           esac
         fi
 
         if [[ $SNAPSHOT_RETAIN != "0" || $SNAPSHOT_METADATA != "0" ]]; then
+            # NOTE: s3Files lines are expected to be in this format: DATE TIME SIZE FILENAME
+            # Where FILENAME is the *basename only* (e.g., "snapshot_2025-04-05.tar.gz"), not a full path.
+            # This mirrors the AWS S3 and Storj uplink `ls` output format for compatibility.
+            # For GCS, we explicitly strip the "gs://bucket/path/" prefix from the filename using `awk` substitution.
             if [ -n "$STORJ_ACCESS_GRANT" ]; then
               SNAPSHOT_METADATA_URL=$(uplink share --url --not-after=none ${storj_uri_base}/ | grep ^URL | awk '{print $NF}')
-	      readarray -t s3Files < <(uplink ls ${storj_uri_base}/ | grep "${SNAPSHOT_PREFIX}_" | awk '{print $2,$3,$4,$5}' | sort -d -k4,4)
+              readarray -t s3Files < <(uplink ls ${storj_uri_base}/ | grep "${SNAPSHOT_PREFIX}_" | awk '{print $2,$3,$4,$5}' | sort -d -k4,4)
+            elif [ "$GCS_ENABLED" == "1" ]; then
+              SNAPSHOT_METADATA_URL="${GCS_PUBLIC_BASE_URL}"
+              readarray -t s3Files < <(gsutil ls -l "${GCS_BUCKET_PATH}/${SNAPSHOT_PREFIX}_"* 2>/dev/null \
+                  | grep -v TOTAL \
+                  | awk -v prefix="${GCS_BUCKET_PATH}/" '{
+                      gsub(/Z$/, "", $2);
+                      gsub(/T/, " ", $2);
+                      sub(prefix, "", $3);
+                      print $2, $1, $3
+                  }')
             else
               readarray -t s3Files < <(s3cmd $aws_args ls "${s3_uri_base}/${SNAPSHOT_PREFIX}_")
             fi
+            # For tracking how many snapshots we're keeping when setting SNAPSHOT_KEEP_LAST != 0
+            snapshot_count="${#s3Files[@]}"
             snapshots=()
             for line in "${s3Files[@]}"; do
                 createDate=`echo $line|awk {'print $1" "$2'}`
@@ -102,16 +163,20 @@ while true; do
                 if [ -n "$STORJ_ACCESS_GRANT" ]; then
 		    fileUrl="${fileUrl}?download=1"
                 fi
-                if [ "$SNAPSHOT_RETAIN" != "0" ]; then
+                if [[ "$SNAPSHOT_RETAIN" != "0" && "$snapshot_count" -gt "$SNAPSHOT_KEEP_LAST" ]]; then
                     olderThan=`date -d"-$SNAPSHOT_RETAIN" +%s`
                     if [[ $createDate -lt $olderThan ]]; then
-                        if [[ $fileName != "" ]]; then
+                        if [[ -n "$fileName" ]]; then
                             echo "$TIME: Deleting snapshot $fileName"
                             if [ -n "$STORJ_ACCESS_GRANT" ]; then
                               uplink rm "${storj_uri_base}/$fileName"
+                            elif [ "$GCS_ENABLED" == "1" ]; then
+                              gsutil rm "${GCS_BUCKET_PATH}/${fileName}"
                             else
                               s3cmd $aws_args del "${s3_uri_base}/$fileName"
                             fi
+                            # decrement the snapshot count after deletion
+                            ((snapshot_count--))
                         fi
                     else
                         snapshots+=("$fileUrl")
@@ -124,9 +189,14 @@ while true; do
             if [ "$SNAPSHOT_METADATA" != "0" ]; then
                 echo "$TIME: Uploading metadata"
                 snapshotJson="[]"
-                for url in ${snapshots[@]}; do
+                if [ ${#snapshots[@]} -gt 0 ]; then
+                  for url in "${snapshots[@]}"; do
                     snapshotJson="$(echo $snapshotJson | jq ".+[\"$url\"]")"
-                done
+                  done
+                else
+                  echo "$TIME: No snapshots found, skipping snapshot.json upload"
+                  continue
+                fi
                 if [ -n "$STORJ_ACCESS_GRANT" ]; then
                   echo $snapshotJson | jq '{chain_id: $c, snapshots: ., latest: $l}' \
                      --arg c "$CHAIN_ID" --arg l "${snapshots[-1]}" | \
@@ -135,6 +205,12 @@ while true; do
                   ##uplink share --url --not-after=none "${storj_uri_base}/snapshot.json" | grep ^URL | awk '{print $NF"?download=1"}'
 		  echo "${SNAPSHOT_METADATA_URL%/}/snapshot.json?download=1"
 		  echo "=== === ==="
+                # GCS
+                elif [ "$GCS_ENABLED" == "1" ]; then
+                  echo $snapshotJson | jq '{chain_id: $c, snapshots: ., latest: $l}' \
+                    --arg c "$CHAIN_ID" --arg l "${snapshots[-1]}" | \
+                    gsutil -q cp - "${GCS_BUCKET_PATH}/snapshot.json"
+                  make_gcs_file_public "snapshot.json"
                 else
                   echo $snapshotJson | jq '{chain_id: $c, snapshots: ., latest: $l}' \
                      --arg c "$CHAIN_ID" --arg l "${snapshots[-1]}" | \


### PR DESCRIPTION
- Updated Dockerfile to install gcloud/gsutil tools
- Integrated `gsutil` for uploading and retrieving snapshot archives from GCS
- Introduced new GCS-related env vars: GCS_ENABLED, GCS_BUCKET_PATH, GCS_KEY_FILE
- Enhanced snapshot script with GCS upload logic and public access ACLs
- Added support for GCS-based backup and restore of `priv_validator_key.json` and `node_key.json`
- Updated README with usage instructions and configuration examples for GCS

Additionally:

- Reordered compression and `pv` piping to ensure progress bar reaches 100% correctly before upload (fix for gzip/zstd snapshots)
- Avoid snapshot.json caching issues by appending `?nocache=<timestamp>` to SNAPSHOT_JSON fetches
- Added `SNAPSHOT_ON_START` option to trigger immediate snapshot on container start
- Added `SNAPSHOT_KEEP_LAST` to retain a minimum number of snapshots regardless of retention policy