### PR TITLE
Upgrade Injective to v1.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ tagged with the form `$COSMOS_OMNIBUS_VERSION-$PROJECT-$PROJECT_VERSION`.
 |[gitopia](https://github.com/gitopia/gitopia)|`v5.1.0`|`ghcr.io/akash-network/cosmos-omnibus:v1.2.14-gitopia-v5.1.0`|[Example](./gitopia)|
 |[gravitybridge](https://github.com/Gravity-Bridge/Gravity-Bridge)|`v1.11.1`|`ghcr.io/akash-network/cosmos-omnibus:v1.2.14-gravitybridge-v1.11.1`|[Example](./gravitybridge)|
 |[impacthub](https://github.com/ixofoundation/ixo-blockchain)|`v0.18.1`|`ghcr.io/akash-network/cosmos-omnibus:v1.2.14-impacthub-v0.18.1`|[Example](./impacthub)|
-|[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.14.1`|`ghcr.io/akash-network/cosmos-omnibus:v1.2.14-injective-v1.14.1`|[Example](./injective)|
+|[injective](https://github.com/InjectiveLabs/injective-chain-releases)|`v1.15.0`|`ghcr.io/akash-network/cosmos-omnibus:v1.2.14-injective-v1.15.0`|[Example](./injective)|
 |[irisnet](https://github.com/irisnet/irishub)|`v3.1.1`|`ghcr.io/akash-network/cosmos-omnibus:v1.2.14-irisnet-v3.1.1`|[Example](./irisnet)|
 |[jackal](https://github.com/JackalLabs/canine-chain)|`v4.5.0`|`ghcr.io/akash-network/cosmos-omnibus:v1.2.14-jackal-v4.5.0`|[Example](./jackal)|
 |[juno](https://github.com/CosmosContracts/Juno)|`v27.0.0`|`ghcr.io/akash-network/cosmos-omnibus:v1.2.14-juno-v27.0.0`|[Example](./juno)|

--- a/injective/README.md
+++ b/injective/README.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-|Version|`v1.14.1`|
+|Version|`v1.15.0`|
 |Binary|`injectived`|
 |Directory|`.injectived`|
 |ENV namespace|`INJECTIVED`|
 |Repository|`https://github.com/InjectiveLabs/injective-chain-releases`|
-|Image|`ghcr.io/akash-network/cosmos-omnibus:v1.2.14-injective-v1.14.1`|
+|Image|`ghcr.io/akash-network/cosmos-omnibus:v1.2.14-injective-v1.15.0`|
 
 ## Examples
 

--- a/injective/build.yml
+++ b/injective/build.yml
@@ -7,8 +7,8 @@ services:
         PROJECT_BIN: injectived
         PROJECT_DIR: .injectived
         REPOSITORY: https://github.com/InjectiveLabs/injective-chain-releases
-        VERSION: v1.14.1
-        BUILD_REF: v1.14.1-1740773301
+        VERSION: v1.15.0
+        BUILD_REF: v1.15.0-1744722790
         BUILD_METHOD: injective
     ports:
       - '26656:26656'

--- a/injective/deploy.yml
+++ b/injective/deploy.yml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v1.2.14-injective-v1.14.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v1.2.14-injective-v1.15.0
     env:
       - MONIKER=Cosmos Omnibus Node
       - P2P_POLKACHU=1

--- a/injective/docker-compose.yml
+++ b/injective/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v1.2.14-injective-v1.14.1
+    image: ghcr.io/akash-network/cosmos-omnibus:v1.2.14-injective-v1.15.0
     ports:
       - '26656:26656'
       - '26657:26657'


### PR DESCRIPTION
📝Summary:

- Upgrade `Injective` binary version to `v1.15.0`
- As a reference:
   - Injective Lyora Mainnet Upgrade [Proposal 518](https://www.mintscan.io/injective/proposals/518)
   - Injective Latest Binary Release: [v1.15.0-1744722790](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.15.0-1744722790)
   - [Polkachu](https://polkachu.com/networks/injective) Current Node Version: `v1.15.0` also updated