### PR TITLE
bump docker & debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG DEBIAN_VERSION=bookworm
-ARG GOLANG_VERSION=1.21
+ARG DEBIAN_VERSION=trixie
+ARG GOLANG_VERSION=1.25
 ARG BUILD_IMAGE=golang:${GOLANG_VERSION}-${DEBIAN_VERSION}
 ARG BUILD_METHOD=source
 ARG BASE_IMAGE=debian:${DEBIAN_VERSION}-slim
@@ -91,7 +91,7 @@ FROM ${BASE_IMAGE} AS base
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --assume-yes \
-    ca-certificates curl wget file unzip zstd liblz4-tool gnupg2 jq s3cmd pv && \
+    ca-certificates curl wget file unzip zstd lz4 gnupg2 jq s3cmd pv && \
     apt-get clean
 
 # Install Storj DCS uplink client


### PR DESCRIPTION
Resolving: #1107 

This PR bumps:
- debian: [trixie-slim](https://hub.docker.com/layers/library/debian/trixie-slim/images/sha256-670646445848e6e94f590170523edbf614da880abdc1ae23c98c9c9ba8f14180)
- golang: [1.25](https://github.com/docker-library/golang/blob/be5c27da377afdeebf0c5747560bedd7f96ccb1c/1.25/trixie/Dockerfile)
- replaces `liblz4-tool` with `lz4`

Debian's latest version inlcudes `deb / debian/glibc / 2.41-12`, resolving issue experienced with images compiled on Ubuntu 24.04 requiring `GLIBC_2.38.`

